### PR TITLE
Add SES integration

### DIFF
--- a/src/proof-of-concept/server/app.js
+++ b/src/proof-of-concept/server/app.js
@@ -20,7 +20,8 @@ const userbaseConfig = {
   httpsKey,
   httpsCert,
   httpsPort,
-  httpPort
+  httpPort,
+  emailDomain: 'encrypted.dev'
 }
 
 const ADMIN_NAME = 'admin'

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -28,12 +28,12 @@ if (process.env.NODE_ENV == 'development') {
 
 async function start(express, app, userbaseConfig = {}) {
   try {
-    await setup.init()
-
     const {
       httpsKey,
       httpsCert
     } = userbaseConfig
+
+    await setup.init(userbaseConfig)
 
     const certExists = httpsKey && httpsCert
     const httpPort = userbaseConfig.httpPort || 8080


### PR DESCRIPTION
Lets us send emails using Amazon SES.

Since emails can only be sent from a verified domain, I've added the domain in the config settings of userbase-server. The POC is using 'encrypted.dev', but the service will use 'userbase.dev'.

To use it, import 'setup' and use the sendEmail exported function. This is probably not the best place for it, but seemed good enough for now.

Also note that right now, our SES account can only send emails to verified recipients. So, make sure you verify your email address when testing: https://us-west-2.console.aws.amazon.com/ses/home?region=us-west-2#verified-senders-email: — We need to wait for Amazon to remove this limit.