### PR TITLE
Password-based key recovery enabled by default

### DIFF
--- a/src/userbase-js/Crypto/index.js
+++ b/src/userbase-js/Crypto/index.js
@@ -3,6 +3,7 @@ import diffieHellman from './diffie-hellman'
 import sha256 from './sha-256'
 import hmac from './hmac'
 import hkdf from './hkdf'
+import pbkdf from './pbkdf'
 
 const SEED_BYTE_SIZE = 32 // 256 / 8
 const generateSeed = () => window.crypto.getRandomValues(new Uint8Array(SEED_BYTE_SIZE))
@@ -14,4 +15,5 @@ export default {
   sha256,
   hmac,
   hkdf,
+  pbkdf,
 }

--- a/src/userbase-js/Crypto/pbkdf.js
+++ b/src/userbase-js/Crypto/pbkdf.js
@@ -1,0 +1,58 @@
+
+import { stringToArrayBuffer } from './utils'
+import sha256 from './sha-256'
+import aesGcm from './aes-gcm'
+
+const PBKDF_ALGORITHM_NAME = 'PBKDF2'
+const RAW_KEY_TYPE = 'raw'
+const KEY_IS_NOT_EXTRACTABLE = false
+const PBKDF_KEY_WILL_BE_USED_TO = ['deriveKey']
+const ENCRYPTION_KEY_WILL_BE_USED_TO = ['encrypt', 'decrypt']
+
+/**
+ * NIST recommendation:
+ *
+ * "the iteration count SHOULD be as large as verification server performance will allow,
+ * typically at least 10,000 iterations."
+ *
+ * https://pages.nist.gov/800-63-3/sp800-63b.html#sec5
+ *
+ **/
+const ITERATIONS = 10000
+
+const SALT_BYTE_SIZE = sha256.BYTE_SIZE
+const generateSalt = () => window.crypto.getRandomValues(new Uint8Array(SALT_BYTE_SIZE))
+
+const importKey = async (passwordString, salt) => {
+  const pbkdfKey = await window.crypto.subtle.importKey(
+    RAW_KEY_TYPE,
+    stringToArrayBuffer(passwordString),
+    {
+      name: PBKDF_ALGORITHM_NAME,
+    },
+    KEY_IS_NOT_EXTRACTABLE,
+    PBKDF_KEY_WILL_BE_USED_TO
+  )
+
+  const encryptionKey = await window.crypto.subtle.deriveKey(
+    {
+      name: PBKDF_ALGORITHM_NAME,
+      salt,
+      iterations: ITERATIONS,
+      hash: {
+        name: sha256.HASH_ALGORITHM_NAME
+      }
+    },
+    pbkdfKey,
+    aesGcm.getEncryptionKeyParams(),
+    KEY_IS_NOT_EXTRACTABLE,
+    ENCRYPTION_KEY_WILL_BE_USED_TO
+  )
+
+  return encryptionKey
+}
+
+export default {
+  generateSalt,
+  importKey
+}

--- a/src/userbase-js/api/auth.js
+++ b/src/userbase-js/api/auth.js
@@ -3,7 +3,8 @@ import config from '../config'
 
 const TEN_SECONDS_MS = 10 * 1000
 
-const signUp = async (username, passwordSecureHash, publicKey, encryptionKeySalt, dhKeySalt, hmacKeySalt, email, profile) => {
+const signUp = async (username, passwordSecureHash, publicKey, encryptionKeySalt,
+  dhKeySalt, hmacKeySalt, email, profile, pbkdfKeySalt, passwordEncryptedSeed) => {
   const signUpResponse = await axios({
     method: 'POST',
     url: `${config.getEndpoint()}/api/auth/sign-up?appId=${config.getAppId()}`,
@@ -15,7 +16,9 @@ const signUp = async (username, passwordSecureHash, publicKey, encryptionKeySalt
       dhKeySalt,
       hmacKeySalt,
       email,
-      profile
+      profile,
+      pbkdfKeySalt,
+      passwordEncryptedSeed
     },
     timeout: TEN_SECONDS_MS
   })

--- a/src/userbase-js/auth.js
+++ b/src/userbase-js/auth.js
@@ -27,9 +27,9 @@ const _parseGenericErrors = (e) => {
   }
 }
 
-const _connectWebSocket = async (appId, sessionId, username, seed, rememberMe, passwordBasedKeyRecoveryEnabled) => {
+const _connectWebSocket = async (appId, sessionId, username, seed, rememberMe, backUpKey) => {
   try {
-    const seedString = await ws.connect(appId, sessionId, username, seed, rememberMe, passwordBasedKeyRecoveryEnabled)
+    const seedString = await ws.connect(appId, sessionId, username, seed, rememberMe, backUpKey)
     return seedString
   } catch (e) {
     _parseGenericErrors(e)
@@ -108,11 +108,11 @@ const _validateSignUpOrSignInInput = (username, password) => {
   _validatePassword(password)
 }
 
-const _generateKeysAndSignUp = async (username, password, seed, email, profile, passwordBasedKeyRecoveryEnabled) => {
+const _generateKeysAndSignUp = async (username, password, seed, email, profile, backUpKey) => {
   const passwordSecureHash = await crypto.sha256.hashString(password)
 
   let pbkdfKeySalt, passwordEncryptedSeed
-  if (passwordBasedKeyRecoveryEnabled) {
+  if (backUpKey) {
     pbkdfKeySalt = await crypto.pbkdf.generateSalt()
     const passwordBasedEncryptionKey = await crypto.pbkdf.importKey(password, pbkdfKeySalt)
     passwordEncryptedSeed = await crypto.aesGcm.encrypt(passwordBasedEncryptionKey, seed)
@@ -173,18 +173,18 @@ const _validateProfile = (profile) => {
   if (!keyExists) throw new errors.ProfileCannotBeEmpty
 }
 
-const displayShowKeyModal = (seedString, rememberMe, passwordBasedKeyRecoveryEnabled) => new Promise(resolve => {
+const displayShowKeyModal = (seedString, rememberMe, backUpKey) => new Promise(resolve => {
   const showKeyModal = document.createElement('div')
   showKeyModal.className = 'userbase-modal'
 
   let message = ' '
-  if (rememberMe && !passwordBasedKeyRecoveryEnabled) {
+  if (rememberMe && !backUpKey) {
     message += 'You will need your secret key to sign in on other devices.'
-  } else if (rememberMe && passwordBasedKeyRecoveryEnabled) {
+  } else if (rememberMe && backUpKey) {
     message += 'If you forget your password, you will need your secret key to sign in on other devices.'
-  } else if (!rememberMe && !passwordBasedKeyRecoveryEnabled) {
+  } else if (!rememberMe && !backUpKey) {
     message += 'Without your secret key, you will not be able to log in to your account.'
-  } else if (!rememberMe && passwordBasedKeyRecoveryEnabled) {
+  } else if (!rememberMe && backUpKey) {
     message += 'If you forget your password, you will not be able to log in to your account without your secret key.'
   }
 
@@ -265,7 +265,7 @@ const displayShowKeyModal = (seedString, rememberMe, passwordBasedKeyRecoveryEna
   closeButton.onclick = hideShowKeyModal
 })
 
-const signUp = async (username, password, email, profile, showKeyHandler, rememberMe = false, passwordBasedKeyRecoveryEnabled = true) => {
+const signUp = async (username, password, email, profile, showKeyHandler, rememberMe = false, backUpKey = true) => {
   try {
     _validateSignUpOrSignInInput(username, password)
     if (profile) _validateProfile(profile)
@@ -278,15 +278,15 @@ const signUp = async (username, password, email, profile, showKeyHandler, rememb
 
     const lowerCaseEmail = email && email.toLowerCase()
 
-    const session = await _generateKeysAndSignUp(lowerCaseUsername, password, seed, lowerCaseEmail, profile, passwordBasedKeyRecoveryEnabled)
+    const session = await _generateKeysAndSignUp(lowerCaseUsername, password, seed, lowerCaseEmail, profile, backUpKey)
     const { sessionId, creationDate } = session
 
     const seedString = base64.encode(seed)
 
     if (showKeyHandler) {
-      await showKeyHandler(seedString, rememberMe, passwordBasedKeyRecoveryEnabled)
+      await showKeyHandler(seedString, rememberMe, backUpKey)
     } else {
-      await displayShowKeyModal(seedString, rememberMe, passwordBasedKeyRecoveryEnabled)
+      await displayShowKeyModal(seedString, rememberMe, backUpKey)
     }
 
     if (rememberMe) {
@@ -294,7 +294,7 @@ const signUp = async (username, password, email, profile, showKeyHandler, rememb
       localData.signInSession(lowerCaseUsername, sessionId, creationDate)
     }
 
-    await _connectWebSocket(appId, sessionId, lowerCaseUsername, seedString, rememberMe, passwordBasedKeyRecoveryEnabled)
+    await _connectWebSocket(appId, sessionId, lowerCaseUsername, seedString, rememberMe, backUpKey)
 
     return _buildUserResult(lowerCaseUsername, seedString, lowerCaseEmail, profile)
   } catch (e) {
@@ -405,9 +405,9 @@ const signIn = async (username, password, rememberMe = false) => {
 
     if (rememberMe) localData.signInSession(lowerCaseUsername, sessionId, creationDate)
 
-    const passwordBasedKeyRecoveryEnabled = passwordBasedBackup ? true : false
+    const backUpKey = passwordBasedBackup ? true : false
 
-    const seedString = await _connectWebSocket(appId, sessionId, username, savedSeedString || seedStringFromBackup, rememberMe, passwordBasedKeyRecoveryEnabled)
+    const seedString = await _connectWebSocket(appId, sessionId, username, savedSeedString || seedStringFromBackup, rememberMe, backUpKey)
 
     if (rememberMe && !savedSeedString) localData.saveSeedString(lowerCaseUsername, seedString)
 
@@ -496,9 +496,9 @@ const signInWithSession = async (appId) => {
 
     const savedSeedString = localData.getSeedString(username) // might be null if does not have seed saved
 
-    const passwordBasedKeyRecoveryEnabled = passwordBasedBackup ? true : false
+    const backUpKey = passwordBasedBackup ? true : false
 
-    const seedString = await _connectWebSocket(appId, sessionId, username, savedSeedString, false, passwordBasedKeyRecoveryEnabled)
+    const seedString = await _connectWebSocket(appId, sessionId, username, savedSeedString, false, backUpKey)
 
     await ws.getRequestsForSeed()
     await ws.getDatabaseAccessGrants()
@@ -619,7 +619,7 @@ const _buildUpdateUserParams = async (user) => {
   if (params.password) {
     params.passwordSecureHash = await crypto.sha256.hashString(params.password)
 
-    if (ws.passwordBasedKeyRecoveryEnabled) {
+    if (ws.backUpKey) {
       const pbkdfKeySalt = await crypto.pbkdf.generateSalt()
       const passwordBasedEncryptionKey = await crypto.pbkdf.importKey(params.password, pbkdfKeySalt)
       const passwordEncryptedSeed = await crypto.aesGcm.encrypt(passwordBasedEncryptionKey, base64.decode(ws.seedString))

--- a/src/userbase-js/auth.js
+++ b/src/userbase-js/auth.js
@@ -173,9 +173,20 @@ const _validateProfile = (profile) => {
   if (!keyExists) throw new errors.ProfileCannotBeEmpty
 }
 
-const displayShowKeyModal = (seedString, rememberMe) => new Promise(resolve => {
+const displayShowKeyModal = (seedString, rememberMe, passwordBasedKeyRecoveryEnabled) => new Promise(resolve => {
   const showKeyModal = document.createElement('div')
   showKeyModal.className = 'userbase-modal'
+
+  let message = ' '
+  if (rememberMe && !passwordBasedKeyRecoveryEnabled) {
+    message += 'You will need your secret key to sign in on other devices.'
+  } else if (rememberMe && passwordBasedKeyRecoveryEnabled) {
+    message += 'If you forget your password, you will need your secret key to sign in on other devices.'
+  } else if (!rememberMe && !passwordBasedKeyRecoveryEnabled) {
+    message += 'Without your secret key, you will not be able to log in to your account.'
+  } else if (!rememberMe && passwordBasedKeyRecoveryEnabled) {
+    message += 'If you forget your password, you will not be able to log in to your account without your secret key.'
+  }
 
   showKeyModal.innerHTML = `
     <div class='userbase-container'>
@@ -226,10 +237,7 @@ const displayShowKeyModal = (seedString, rememberMe) => new Promise(resolve => {
     <span class='fas userbase-fa-exclamation-triangle' />
     <span class='userbase-text-line'>
 
-    Store this key somewhere safe. ${rememberMe
-      ? ' You will need your secret key to sign in on other devices.'
-      : ' Without it, you will not be able to log in to your account.'
-    }
+    Store this key somewhere safe.${message}
 
     </span>
     </div>
@@ -259,9 +267,6 @@ const displayShowKeyModal = (seedString, rememberMe) => new Promise(resolve => {
 
 const signUp = async (username, password, email, profile, showKeyHandler, rememberMe = false, passwordBasedKeyRecoveryEnabled = true) => {
   try {
-    console.log(passwordBasedKeyRecoveryEnabled)
-
-
     _validateSignUpOrSignInInput(username, password)
     if (profile) _validateProfile(profile)
     if (showKeyHandler && typeof showKeyHandler !== 'function') throw new errors.ShowKeyHandlerMustBeFunction
@@ -279,9 +284,9 @@ const signUp = async (username, password, email, profile, showKeyHandler, rememb
     const seedString = base64.encode(seed)
 
     if (showKeyHandler) {
-      await showKeyHandler(seedString, rememberMe)
+      await showKeyHandler(seedString, rememberMe, passwordBasedKeyRecoveryEnabled)
     } else {
-      await displayShowKeyModal(seedString, rememberMe)
+      await displayShowKeyModal(seedString, rememberMe, passwordBasedKeyRecoveryEnabled)
     }
 
     if (rememberMe) {

--- a/src/userbase-js/ws.js
+++ b/src/userbase-js/ws.js
@@ -35,7 +35,7 @@ class Connection {
     this.init()
   }
 
-  init(resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe, passwordBasedKeyRecoveryEnabled) {
+  init(resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe, backUpKey) {
     for (const property of Object.keys(this)) {
       delete this[property]
     }
@@ -57,7 +57,7 @@ class Connection {
     }
 
     this.rememberMe = rememberMe
-    this.passwordBasedKeyRecoveryEnabled = passwordBasedKeyRecoveryEnabled
+    this.backUpKey = backUpKey
 
     this.requests = {}
 
@@ -73,7 +73,7 @@ class Connection {
     }
   }
 
-  connect(appId, sessionId, username, seedString = null, rememberMe = false, passwordBasedKeyRecoveryEnabled = true) {
+  connect(appId, sessionId, username, seedString = null, rememberMe = false, backUpKey = true) {
     if (this.connected) throw new WebSocketError(wsAlreadyConnected, this.username)
 
     return new Promise((resolve, reject) => {
@@ -106,7 +106,7 @@ class Connection {
           return
         }
 
-        this.init(resolve, reject, username, sessionId, seedString, rememberMe, passwordBasedKeyRecoveryEnabled)
+        this.init(resolve, reject, username, sessionId, seedString, rememberMe, backUpKey)
         this.ws = ws
 
         if (!seedString) {

--- a/src/userbase-js/ws.js
+++ b/src/userbase-js/ws.js
@@ -35,7 +35,7 @@ class Connection {
     this.init()
   }
 
-  init(resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe) {
+  init(resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe, passwordBasedKeyRecoveryEnabled) {
     for (const property of Object.keys(this)) {
       delete this[property]
     }
@@ -57,6 +57,7 @@ class Connection {
     }
 
     this.rememberMe = rememberMe
+    this.passwordBasedKeyRecoveryEnabled = passwordBasedKeyRecoveryEnabled
 
     this.requests = {}
 
@@ -72,7 +73,7 @@ class Connection {
     }
   }
 
-  connect(appId, sessionId, username, seedString = null, rememberMe = false) {
+  connect(appId, sessionId, username, seedString = null, rememberMe = false, passwordBasedKeyRecoveryEnabled = true) {
     if (this.connected) throw new WebSocketError(wsAlreadyConnected, this.username)
 
     return new Promise((resolve, reject) => {
@@ -105,7 +106,7 @@ class Connection {
           return
         }
 
-        this.init(resolve, reject, username, sessionId, seedString, rememberMe)
+        this.init(resolve, reject, username, sessionId, seedString, rememberMe, passwordBasedKeyRecoveryEnabled)
         this.ws = ws
 
         if (!seedString) {

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -143,7 +143,9 @@ async function start(express, app, userbaseConfig = {}) {
                   params.username,
                   params.passwordSecureHash,
                   params.email,
-                  params.profile
+                  params.profile,
+                  params.pbkdfKeySalt,
+                  params.passwordEncryptedSeed
                 )
                 break
               }


### PR DESCRIPTION
- unless `passwordBasedKeyRecoveryEnabled` is set to false via the param to `signUp()`, an encryption key will be derived from the user's password via PBKDF2, this key will be used to encrypt the user's seed, and the encrypted seed will be stored on the server
- on signIn(), the encrypted seed will be returned to the client, then decrypted with the password. This way a user only needs their password to sign in by default
- updateUser() re-encrypts the seed using the new password if the user has password-based recovery enabled