### PR TITLE
WebSocket auto reconnect

### DIFF
--- a/src/userbase-js/auth.js
+++ b/src/userbase-js/auth.js
@@ -314,7 +314,7 @@ const signUp = async (username, password, email, profile, showKeyHandler, rememb
 
 const signOut = async () => {
   try {
-    if (!ws.connected) throw new errors.UserNotSignedIn
+    if (!ws.username) throw new errors.UserNotSignedIn
 
     try {
       await ws.signOut()
@@ -487,6 +487,7 @@ const importKey = async (keyString) => {
     if (typeof keyString !== 'string') throw new errors.KeyMustBeString
     if (keyString.length === 0) throw new errors.KeyCannotBeBlank
 
+    if (ws.reconnecting) throw new errors.Reconnecting
     if (!ws.connected) throw new errors.UserNotSignedIn
 
     try {
@@ -593,6 +594,7 @@ const updateUser = async (user) => {
     const action = 'UpdateUser'
     const params = await _buildUpdateUserParams(user)
 
+    if (ws.reconnecting) throw new errors.Reconnecting
     if (!ws.keys.init) throw new errors.UserNotSignedIn
     try {
       if (ws.rememberMe && params.username) localData.saveSeedString(params.username, ws.seedString)

--- a/src/userbase-js/db.js
+++ b/src/userbase-js/db.js
@@ -414,6 +414,7 @@ const _validateDbInput = (dbName) => {
   if (dbName.length === 0) throw new errors.DatabaseNameCannotBeBlank
   if (dbName.length > MAX_DB_NAME_CHAR_LENGTH) throw new errors.DatabaseNameTooLong(MAX_DB_NAME_CHAR_LENGTH)
 
+  if (ws.reconnecting) throw new errors.Reconnecting
   if (!ws.keys.init) throw new errors.UserNotSignedIn
 }
 

--- a/src/userbase-js/errors/index.js
+++ b/src/userbase-js/errors/index.js
@@ -39,6 +39,14 @@ class Timeout extends ServiceUnavailable {
   }
 }
 
+class Reconnecting extends ServiceUnavailable {
+  constructor(...params) {
+    super(...params)
+
+    this.message = 'Reconnecting.'
+  }
+}
+
 export default {
   ...auth,
   ...db,
@@ -46,5 +54,6 @@ export default {
   AppIdNotSet,
   InternalServerError,
   ServiceUnavailable,
-  Timeout
+  Timeout,
+  Reconnecting
 }

--- a/src/userbase-js/ws.js
+++ b/src/userbase-js/ws.js
@@ -10,6 +10,11 @@ import errors from './errors'
 
 const wsAlreadyConnected = 'Web Socket already connected'
 
+const BACKOFF_RETRY_DELAY = 1000
+const MAX_RETRY_DELAY = 1000 * 30
+
+const SERVICE_RESTART = 1012
+
 class RequestFailed extends Error {
   constructor(action, response, ...params) {
     super(...params)
@@ -72,7 +77,7 @@ class Connection {
     }
   }
 
-  connect(appId, sessionId, username, seedString = null, rememberMe = false) {
+  connect(appId, sessionId, username, seedString = null, rememberMe = false, reconnectDelay) {
     if (this.connected) throw new WebSocketError(wsAlreadyConnected, this.username)
 
     return new Promise((resolve, reject) => {
@@ -82,7 +87,6 @@ class Connection {
         () => {
           if (!this.connected) {
             timeout = true
-            this.close()
             reject(new WebSocketError('timeout'))
           }
         },
@@ -100,7 +104,6 @@ class Connection {
         if (timeout) return
 
         if (this.connected) {
-          this.close()
           reject(new WebSocketError(wsAlreadyConnected, username))
           return
         }
@@ -128,19 +131,94 @@ class Connection {
         }
       }
 
-      ws.onerror = () => {
-        if (!this.connected) {
-          reject(new WebSocketError('WebSocket error'))
-        }
-        this.close()
-      }
+      ws.onclose = async (e) => {
+        if (timeout) return
 
-      ws.onclose = () => {
-        this.init()
+        const serviceRestart = e.code === SERVICE_RESTART
+        const attemptToReconnect = serviceRestart || !e.wasClean // closed without explicit call to ws.close()
+
+        if (attemptToReconnect) {
+          const delay = (serviceRestart && !reconnectDelay)
+            ? 0
+            : (reconnectDelay ? reconnectDelay + BACKOFF_RETRY_DELAY : 1000)
+
+          await this.reconnect(delay, appId, resolve, reject, username, sessionId, seedString, rememberMe)
+        } else {
+          this.init()
+        }
       }
     })
   }
 
+  async reconnect(reconnectDelay, appId, resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe) {
+    try {
+      const retryDelay = Math.min(reconnectDelay, MAX_RETRY_DELAY)
+      console.log(`Connection to server lost. Attempting to reconnect in ${retryDelay / 1000} second${retryDelay !== 1000 ? 's' : ''}...`)
+
+      resolveConnection(await new Promise((resolve, reject) => setTimeout(
+        async () => {
+          try {
+            const state = {
+              databases: { ...this.state.databases },
+              dbIdToHash: { ...this.state.dbIdToHash },
+              dbNameToHash: { ...this.state.dbNameToHash }
+            }
+
+            for (const dbNameHash in state.databases) {
+              state.databases[dbNameHash].init = false
+            }
+
+            this.init()
+
+            // setting this.state = state here and after connect() maintains memory references
+            this.state = state
+            const result = await this.connect(appId, sessionId, username, seedString, rememberMe, reconnectDelay)
+            this.state = state
+
+            resolve(result)
+          } catch (e) {
+            reject(e)
+          }
+        },
+        retryDelay
+      )))
+
+      await this.reopenDatabases(1000)
+    } catch (e) {
+      rejectConnection(e)
+    }
+  }
+
+  async reopenDatabases(retryDelay) {
+    try {
+      const openDatabasePromises = []
+
+      for (const dbNameHash in this.state.databases) {
+        if (!this.state.databases[dbNameHash].reopening) {
+          this.state.databases[dbNameHash].reopening = true
+          const action = 'OpenDatabase'
+          const params = { dbNameHash }
+          openDatabasePromises.push(this.request(action, params))
+        }
+      }
+
+      await Promise.all(openDatabasePromises)
+
+    } catch (e) {
+      for (const dbNameHash in this.state.databases) {
+        this.state.databases[dbNameHash].reopening = false
+      }
+
+      // keep attempting to reopen on failure
+      await new Promise(resolve => setTimeout(
+        async () => {
+          await this.reopenDatabases(retryDelay + BACKOFF_RETRY_DELAY)
+          resolve()
+        },
+        Math.min(retryDelay, MAX_RETRY_DELAY)
+      ))
+    }
+  }
   async handleMessage(message) {
     const route = message.route
     switch (route) {

--- a/src/userbase-js/ws.js
+++ b/src/userbase-js/ws.js
@@ -173,6 +173,7 @@ class Connection {
             }
 
             this.init()
+            this.reconnecting = true
 
             // setting this.state = state here and after connect() maintains memory references
             this.state = state
@@ -412,6 +413,8 @@ class Connection {
       if (this.rememberMe) localData.signOutSession(username)
 
       const sessionId = this.sessionId
+
+      if (this.reconnecting) throw new errors.Reconnecting
 
       const action = 'SignOut'
       const params = { sessionId }


### PR DESCRIPTION
When the WebSocket connection drops, this PR ensures the client attempts to re-open the connection and then re-open already opened databases. As discussed, it uses a linear backoff of 1 second (i.e. attempt to reconnect in 1s, re-attempt in 2s on failure, re-attempt in 3s on failure) to a max of 30 seconds.

## Interesting Highlights

### Updated Ping Implementation

The server now explicitly sends a 'Ping' message to the client over the WebSocket every 30 seconds. If the client does not receive a 'Ping' message from the server every 30 seconds (+ latency), the SDK can assume the client's internet connection was dropped and triggers the reconnect. If the server does not receive a 'Pong' message from the client every 30 seconds, the server terminates the connection same as before.

### Reconnecting Error

When the WebSocket is in the process of reconnecting, all functions that expect it to be connected will throw the ServiceUnavailable error with message "Reconnecting."
