### PR TITLE
Fixed DDB transaction conflict on concurrent Userbase transactions, openDatabase, and signUp

### DIFF
--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -16,6 +16,8 @@ const createDatabase = async function (userId, dbNameHash, dbId, encryptedDbName
     const user = await userController.getUserByUserId(userId)
     if (!user || user['deleted']) throw new Error('UserNotFound')
 
+    memcache.initTransactionLog(dbId)
+
     const database = {
       'database-id': dbId,
       'owner-id': userId,
@@ -48,20 +50,17 @@ const createDatabase = async function (userId, dbNameHash, dbId, encryptedDbName
             '#userId': 'user-id',
           }
         }
-      }, {
-        ConditionCheck: userController.conditionCheckUserExists(user['username'], user['app-id'], userId)
       }]
     }
 
     const ddbClient = connection.ddbClient()
     await ddbClient.transactWrite(params).promise()
 
-    memcache.initTransactionLog(dbId)
-
+    return { ...database, ...userDatabase }
   } catch (e) {
 
     if (e.message) {
-      if (e.message.includes('ConditionalCheckFailed]') || e.message.includes('UserNotFound')) {
+      if (e.message.includes('UserNotFound')) {
         return responseBuilder.errorResponse(statusCodes['Conflict'], 'UserNotFound')
       } else if (e.message.includes('ConditionalCheckFailed')) {
         return responseBuilder.errorResponse(statusCodes['Conflict'], 'Database already exists')
@@ -123,14 +122,17 @@ exports.openDatabase = async function (userId, connectionId, dbNameHash, newData
   if (!encryptedDbKey) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database key')
 
   try {
+    let database
     try {
-      await createDatabase(userId, dbNameHash, newDbId, encryptedDbName, encryptedDbKey)
+      database = await getDatabase(userId, dbNameHash) || await createDatabase(userId, dbNameHash, newDbId, encryptedDbName, encryptedDbKey)
     } catch (e) {
-      // safe to continue if database already exists, otherwise return error response
-      if (e.data !== 'Database already exists') return responseBuilder.errorResponse(e.status, e.data)
+      if (e.data === 'Database already exists' || e.data === 'Database already creating') {
+        // User must have made a concurrent request to open db with same name for the first time.
+        // Can safely reattempt to get the database
+        database = await getDatabase(userId, dbNameHash)
+      }
+      else return responseBuilder.errorResponse(e.status, e.data)
     }
-
-    const database = await getDatabase(userId, dbNameHash)
     if (!database) return responseBuilder.errorResponse(statusCodes['Not Found'], 'Database not found')
 
     const dbId = database['database-id']
@@ -197,62 +199,35 @@ const rollbackTransaction = async function (transaction) {
 
 exports.rollbackTransaction = rollbackTransaction
 
-const failedTxConditionCheckMsg = 'Make sure user has write permission to this db and the db id and hash are correct'
 const putTransaction = async function (transaction, userId, dbNameHash, databaseId) {
-  const user = await userController.getUserByUserId(userId)
+  const [user, database] = await Promise.all([
+    userController.getUserByUserId(userId),
+    getDatabase(userId, dbNameHash)
+  ])
+
   if (!user || user['deleted']) throw new Error('UserNotFound')
+  if (!database) throw new Error('DatabaseNotFound')
+  if (database['read-only']) throw new Error('DatabaseIsReadOnly')
 
   const transactionWithSequenceNo = memcache.pushTransaction(transaction)
 
   const params = {
-    TransactItems: [{
-      ConditionCheck: {
-        TableName: setup.userDatabaseTableName,
-        Key: {
-          'user-id': userId,
-          'database-name-hash': dbNameHash
-        },
-        // ensure user has write permissions and db id matches
-        ConditionExpression: '#readOnly <> :readOnly and #dbId = :dbId',
-        ExpressionAttributeNames: {
-          '#readOnly': 'read-only',
-          '#dbId': 'database-id',
-        },
-        ExpressionAttributeValues: {
-          ':readOnly': true,
-          ':dbId': databaseId,
-        },
-      }
-    }, {
-      Put: {
-        TableName: setup.transactionsTableName,
-        Item: transactionWithSequenceNo,
-        ConditionExpression: 'attribute_not_exists(#databaseId)',
-        ExpressionAttributeNames: {
-          '#databaseId': 'database-id'
-        },
-      }
-    }, {
-      ConditionCheck: userController.conditionCheckUserExists(user['username'], user['app-id'], userId)
-    }]
+    TableName: setup.transactionsTableName,
+    Item: transactionWithSequenceNo,
+    ConditionExpression: 'attribute_not_exists(#databaseId)',
+    ExpressionAttributeNames: {
+      '#databaseId': 'database-id'
+    }
   }
 
   try {
     const ddbClient = connection.ddbClient()
-    await ddbClient.transactWrite(params).promise()
+    await ddbClient.put(params).promise()
 
     memcache.transactionPersistedToDdb(transactionWithSequenceNo)
   } catch (e) {
-    if (e.name === 'TransactionCanceledException') {
+    if (e.name === 'ConditionalCheckFailedException') {
       memcache.transactionCancelled(transactionWithSequenceNo)
-
-      // impossible to determine which condition in the expression failed
-      if (e.message.includes('[ConditionalCheckFailed')) {
-        throw new Error(failedTxConditionCheckMsg)
-      } else if (e.message.includes('ConditionalCheckFailed]')) {
-        throw new Error('UserNotFound')
-      }
-
     } else {
       logger.warn(`Transaction ${transactionWithSequenceNo['sequence-no']} failed for user ${userId} on db ${databaseId} with ${e}! Rolling back...`)
       rollbackTransaction(transactionWithSequenceNo)
@@ -283,8 +258,9 @@ exports.doCommand = async function (command, userId, dbNameHash, databaseId, key
     const sequenceNo = await putTransaction(transaction, userId, dbNameHash, databaseId)
     return responseBuilder.successResponse({ sequenceNo })
   } catch (e) {
-    if (e.message === failedTxConditionCheckMsg) return responseBuilder.errorResponse(statusCodes['Bad Request'], failedTxConditionCheckMsg)
-    else if (e.message === 'UserNotFound') return responseBuilder.errorResponse(statusCodes['Not Found'], 'UserNotFound')
+    if (e.message === 'UserNotFound') return responseBuilder.errorResponse(statusCodes['Not Found'], 'UserNotFound')
+    else if (e.message === 'DatabaseNotFound') return responseBuilder.errorResponse(statusCodes['Not Found'], 'DatabaseNotFound')
+    else if (e.message === 'DatabaseIsReadOnly') return responseBuilder.errorResponse(statusCodes['Unauthorized'], 'DatabaseIsReadOnly')
 
     logger.warn(`Failed command ${command} for user ${userId} with ${e}`)
     return responseBuilder.errorResponse(statusCodes['Internal Server Error'], `Failed to ${command}`)
@@ -331,8 +307,9 @@ exports.batchTransaction = async function (userId, dbNameHash, databaseId, opera
     const sequenceNo = await putTransaction(transaction, userId, dbNameHash, databaseId)
     return responseBuilder.successResponse({ sequenceNo })
   } catch (e) {
-    if (e.message === failedTxConditionCheckMsg) return responseBuilder.errorResponse(statusCodes['Bad Request'], failedTxConditionCheckMsg)
-    else if (e.message === 'UserNotFound') return responseBuilder.errorResponse(statusCodes['Not Found'], 'UserNotFound')
+    if (e.message === 'UserNotFound') return responseBuilder.errorResponse(statusCodes['Not Found'], 'UserNotFound')
+    else if (e.message === 'DatabaseNotFound') return responseBuilder.errorResponse(statusCodes['Not Found'], 'DatabaseNotFound')
+    else if (e.message === 'DatabaseIsReadOnly') return responseBuilder.errorResponse(statusCodes['Unauthorized'], 'DatabaseIsReadOnly')
 
     logger.warn(`Failed batch transaction for user ${userId} with ${e}`)
     return responseBuilder.errorResponse(statusCodes['Internal Server Error'], 'Failed to batch transaction')


### PR DESCRIPTION
This PR fixes issues arising from concurrent DDB TransactionWrites. Note that it still seemed necessary to use DDB's TransactWrite for 2 things:

1. Creating a database is a DDB transaction that inserts both the `database` AND `userDatabase`. Complex nuance: a transaction conflict may arise if a user concurrently calls  `openDatabase` with the same name _before_ having successfully called it once, however this DDB transaction guarantees both `database` and `userDatabase` are created together (i.e. one can never exist without the other which would cause other potential safety issues). Even if this transaction conflict does arise though, [this query in the catch block](https://github.com/encrypted-dev/userbase/compare/tx-conflict?expand=1#diff-62050e09b89b49d8d0911769ef6bd8c7R129-R133) helps improve concurrency safely

2. Updating a user with a new username deletes the old DDB item (since the username is the partition key) and inserts a new DDB item _inside a DDB transaction_. This guarantees that the old username will definitely be removed from DDB while the new one is inserted, though it prevents a user from making concurrent calls to `updateUser` with a new username.

Copied the rest from Basecamp to explain the issue this PR is solving in more detail:

### Summary of the issue

On insertItem/updateItem/deleteItem, when the backend inserts the transaction into the user’s transaction log, it uses a DDB transaction to ensure the following conditions are met:

- The user has write access to the database and the database exists ([source](https://github.com/encrypted-dev/userbase/blob/172ce59f6c69b7d5d3ae17fde04d3865d29c259c/src/userbase-server/db.js#L209-L225))
- The user exists and has not been deleted ([source](https://github.com/encrypted-dev/userbase/blob/172ce59f6c69b7d5d3ae17fde04d3865d29c259c/src/userbase-server/db.js#L236))

These condition checks prevent concurrent transactions. From the [DDB docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-conflict-handling):

```
A transactional conflict can occur during concurrent item-level requests on an item within a transaction.  Transaction conflicts can occur in the following scenarios:
…
An item within a TransactWriteItems request is part of another ongoing TransactWriteItems request.
```

Even though the ConditionCheck is just a read, since those checks read the same database + user items across concurrent transactions, DDB is throwing the TransactionConflict error.

This is my bad for missing this. I do recall manually testing concurrent transactions. I think I only tested it with a small number and didn’t trigger the conflict. Thankful for Luka's testing :D

### Naive Solution

- Remove the ConditionChecks from the DDB transaction
- Test for the conditions outside of a DDB transaction by simply reading the DDB tables prior to inserting in the transaction log

With this naive solution, it will be possible (though rare) for a user to insert a transaction that violates the 2 conditions listed above.

For example, if a user deletes their account and simultaneously performs a bunch of inserts, it's possible the inserts will succeed for a short period of time even after the account was deleted.

As far as I understand, SQL offers a wider range of tools to handle this issue (FK constraints, Postgres' ON CONFLICT, triggers), but I don't see a better way to handle this with DDB while allowing for concurrency. But the worst case scenario seems ok to me
