### PR TITLE
Implemented delete admin

### DIFF
--- a/src/userbase-server/admin-panel/App.jsx
+++ b/src/userbase-server/admin-panel/App.jsx
@@ -3,6 +3,7 @@ import AdminForm from './components/Admin/AdminForm'
 import adminLogic from './components/Admin/logic'
 import Dashboard from './components/Dashboard/Dashboard'
 import AppUsersTable from './components/Dashboard/AppUsersTable'
+import EditAdmin from './components/Admin/EditAdmin'
 
 export default class App extends Component {
   constructor(props) {
@@ -49,6 +50,11 @@ export default class App extends Component {
           ? window.location.hash = ''
           : this.setState({ mode: hashRoute })
 
+      case 'edit-account':
+        return signedIn
+          ? this.setState({ mode: hashRoute })
+          : window.location.hash = ''
+
       default:
         if (hashRoute && hashRoute.substring(0, 4) === 'app=' && signedIn) {
           return this.setState({ mode: 'app-users-table' })
@@ -83,7 +89,7 @@ export default class App extends Component {
                 <li className='inline-block ml-4'><a className={mode === 'create-admin' ? 'text-orange-600' : ''} href='#create-admin'>New admin</a></li>
               </ul>
               : <ul>
-                <li className='inline-block ml-4 font-light'>{adminName}</li>
+                <li className='inline-block ml-4 font-light'><a className={mode === 'edit-account' ? 'text-orange-600' : ''} href='#edit-account'>{adminName}</a></li>
                 <li className='inline-block ml-4'><a href='#' onClick={this.handleSignOut}>Sign out</a></li>
               </ul>
             }
@@ -114,6 +120,9 @@ export default class App extends Component {
                 appName={decodeURIComponent(window.location.hash.substring(5))}
                 key={window.location.hash} // re-renders on hash change
               />
+
+            case 'edit-account':
+              return <EditAdmin />
 
             default:
               return null

--- a/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
@@ -1,0 +1,57 @@
+import React, { Component } from 'react'
+import adminLogic from './logic'
+
+export default class EditAdmin extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      error: '',
+      loading: false
+    }
+
+    this.handleDeleteAccount = this.handleDeleteAccount.bind(this)
+  }
+
+  componentDidMount() {
+    this._isMounted = true
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false
+  }
+
+  async handleDeleteAccount(event) {
+    event.preventDefault()
+
+    try {
+      if (window.confirm('Are you sure you want to delete your account?')) {
+        this.setState({ loading: true })
+        await adminLogic.deleteAdmin()
+      }
+    } catch (e) {
+      if (this._isMounted) this.setState({ error: e.message, loading: false })
+    }
+  }
+
+  render() {
+    const { error, loading } = this.state
+
+    return (
+      <div className='container content text-xs xs:text-base'>
+
+        <div className='text-center'>
+          <input
+            className='btn w-40'
+            type='button'
+            value={loading ? 'Deleting...' : 'Delete Account'}
+            disabled={loading}
+            onClick={this.handleDeleteAccount}
+          />
+
+          {error && <div className='error'>{error}</div>}
+        </div>
+
+      </div>
+    )
+  }
+}

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -34,6 +34,10 @@ const signOutLocalSession = () => {
   localStorage.setItem('adminSession', signedOutSession)
 }
 
+const removeLocalSession = () => {
+  localStorage.removeItem('adminSession')
+}
+
 const createAdmin = async (adminName, password, fullName) => {
   try {
     const lowerCaseAdminName = adminName.toLowerCase()
@@ -109,6 +113,20 @@ const forgotPassword = async (adminName) => {
   }
 }
 
+const deleteAdmin = async () => {
+  try {
+    await axios({
+      method: 'POST',
+      url: `/${VERSION}/admin/delete-admin`,
+      timeout: TEN_SECONDS_MS
+    })
+    removeLocalSession()
+    window.location.hash = ''
+  } catch (e) {
+    errorHandler(e)
+  }
+}
+
 export default {
   createAdmin,
   createApp,
@@ -116,5 +134,6 @@ export default {
   handleSignOut,
   signIn,
   errorHandler,
-  forgotPassword
+  forgotPassword,
+  deleteAdmin
 }

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -254,6 +254,7 @@ async function start(express, app, userbaseConfig = {}) {
     v1.post('/admin/list-app-users', admin.authenticateAdmin, appController.listAppUsers)
     v1.post('/admin/delete-app', admin.authenticateAdmin, appController.deleteApp)
     v1.post('/admin/delete-user', admin.authenticateAdmin, admin.deleteUser)
+    v1.post('/admin/delete-admin', admin.authenticateAdmin, admin.deleteAdmin)
     v1.post('/admin/forgot-password', admin.forgotPassword)
 
     app.get('/ping', function (req, res) {

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -8,6 +8,7 @@ import connections from './ws'
 import logger from './logger'
 import { validateEmail, stringToArrayBuffer } from './utils'
 import appController from './app'
+import adminController from './admin'
 
 const getTtl = secondsToLive => Math.floor(Date.now() / 1000) + secondsToLive
 
@@ -203,6 +204,9 @@ exports.signUp = async function (req, res) {
     const app = await appController.getAppByAppId(appId)
     if (!app || app['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
 
+    const admin = await adminController.findAdminByAdminId(app['admin-id'])
+    if (!admin || admin['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
+
     const salts = { encryptionKeySalt, dhKeySalt, hmacKeySalt }
     const passwordBasedBackup = { pbkdfKeySalt, passwordEncryptedSeed }
 
@@ -271,6 +275,9 @@ exports.authenticateUser = async function (req, res, next) {
 
     if (!user || user['deleted']) return res.status(statusCodes['Unauthorized']).send('Session invalid')
     if (!app || app['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
+
+    const admin = await adminController.findAdminByAdminId(app['admin-id'])
+    if (!admin || admin['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
 
     res.locals.user = user // makes user object available in next route
     next()
@@ -380,6 +387,9 @@ exports.signIn = async function (req, res) {
     // Warning: uses secondary index here. It's possible index won't be up to date and this fails
     const app = await appController.getAppByAppId(appId)
     if (!app || app['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
+
+    const admin = await adminController.findAdminByAdminId(app['admin-id'])
+    if (!admin || admin['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
 
     const params = {
       TableName: setup.usersTableName,
@@ -732,6 +742,9 @@ exports.forgotPassword = async function (req, res) {
     // Warning: uses secondary index here. It's possible index won't be up to date and this fails
     const app = await appController.getAppByAppId(appId)
     if (!app || app['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
+
+    const admin = await adminController.findAdminByAdminId(app['admin-id'])
+    if (!admin || admin['deleted']) return res.status(statusCodes['Unauthorized']).send('App ID not valid')
 
     const tempPassword = crypto
       .randomBytes(ACCEPTABLE_RANDOM_BYTES_FOR_SAFE_SESSION_ID)


### PR DESCRIPTION
As discussed, in addition to making admin accounts inaccessible after delete is called, all admin's apps become inaccessible to users on their next sign in.

Couple notes on this PR:
- In the gif, you'll see the admin can click their account in the top right which brings up a new page where the "Delete Account" button is. Planning to allow the admin to edit their account on that page as well (to change their name, email, password).
- I introduced a circular dependency in userbase-server. `admin.js` now imports `user.js`. `user.js` imports `admin.js`. The code compiles and runs fine, but it's a code smell I wanted to highlight. I would personally solve this with a general restructuring of the server into a pattern of controllers -> services -> db operations where each level has clear roles. This would have other benefits in forcing cleaner/consistent code, though it would take a while and the benefit at this particular point in time seems low. Wanted to bring attention to this.

![DeleteAdmin](https://user-images.githubusercontent.com/26468430/70476570-d8e6c480-1a8b-11ea-9794-609664c5b07e.gif)
