### PR TITLE
Admin update account

### DIFF
--- a/src/proof-of-concept/server/app.js
+++ b/src/proof-of-concept/server/app.js
@@ -24,7 +24,7 @@ const userbaseConfig = {
   emailDomain: 'encrypted.dev'
 }
 
-const ADMIN_NAME = 'admin'
+const ADMIN_EMAIL = 'admin@userbase.dev'
 const ADMIN_ID = 'admin-id'
 
 const APP_NAME = 'proof-of-concept'
@@ -51,7 +51,7 @@ async function setupAdmin() {
       storePasswordInSecretsManager = true
     }
 
-    await userbaseServer.createAdmin(ADMIN_NAME, adminPassword, ADMIN_ID, storePasswordInSecretsManager)
+    await userbaseServer.createAdmin(ADMIN_EMAIL, adminPassword, ADMIN_ID, storePasswordInSecretsManager)
   } catch (e) {
     if (!e || e.status !== CONFLICT_STATUS_CODE) {
       console.log(`Failed to set up new admin account with ${JSON.stringify(e)}`)

--- a/src/proof-of-concept/server/app.js
+++ b/src/proof-of-concept/server/app.js
@@ -26,6 +26,7 @@ const userbaseConfig = {
 
 const ADMIN_EMAIL = 'admin@userbase.dev'
 const ADMIN_ID = 'admin-id'
+const ADMIN_FULL_NAME = 'Default Admin'
 
 const APP_NAME = 'proof-of-concept'
 const APP_ID = 'poc-id'
@@ -51,7 +52,7 @@ async function setupAdmin() {
       storePasswordInSecretsManager = true
     }
 
-    await userbaseServer.createAdmin(ADMIN_EMAIL, adminPassword, ADMIN_ID, storePasswordInSecretsManager)
+    await userbaseServer.createAdmin(ADMIN_EMAIL, adminPassword, ADMIN_FULL_NAME, ADMIN_ID, storePasswordInSecretsManager)
   } catch (e) {
     if (!e || e.status !== CONFLICT_STATUS_CODE) {
       console.log(`Failed to set up new admin account with ${JSON.stringify(e)}`)

--- a/src/userbase-server/admin-panel/App.jsx
+++ b/src/userbase-server/admin-panel/App.jsx
@@ -11,7 +11,7 @@ export default class App extends Component {
 
     this.state = {
       mode: undefined,
-      adminName: undefined
+      email: undefined
     }
 
     this.handleSignOut = this.handleSignOut.bind(this)
@@ -35,10 +35,10 @@ export default class App extends Component {
     const sessionJson = localStorage.getItem('adminSession')
     const session = sessionJson && JSON.parse(sessionJson)
     const signedIn = session && session.signedIn
-    const adminName = session && session.adminName
+    const email = session && session.email
 
-    if (adminName && adminName !== this.state.adminName) {
-      this.setState({ adminName: session.adminName })
+    if (email && email !== this.state.email) {
+      this.setState({ email: session.email })
     }
 
     const hashRoute = window.location.hash.substring(1)
@@ -67,7 +67,7 @@ export default class App extends Component {
   }
 
   render() {
-    const { mode, adminName } = this.state
+    const { mode, email } = this.state
 
     if (!mode) {
       return <div />
@@ -89,7 +89,7 @@ export default class App extends Component {
                 <li className='inline-block ml-4'><a className={mode === 'create-admin' ? 'text-orange-600' : ''} href='#create-admin'>New admin</a></li>
               </ul>
               : <ul>
-                <li className='inline-block ml-4 font-light'><a className={mode === 'edit-account' ? 'text-orange-600' : ''} href='#edit-account'>{adminName}</a></li>
+                <li className='inline-block ml-4 font-light'><a className={mode === 'edit-account' ? 'text-orange-600' : ''} href='#edit-account'>{email}</a></li>
                 <li className='inline-block ml-4'><a href='#' onClick={this.handleSignOut}>Sign out</a></li>
               </ul>
             }
@@ -102,14 +102,14 @@ export default class App extends Component {
               return <AdminForm
                 formType='Create Admin'
                 key='create-admin'
-                placeholderAdminName=''
+                placeholderEmail=''
               />
 
             case 'sign-in':
               return <AdminForm
                 formType='Sign In'
                 key='sign-in'
-                placeholderAdminName={adminName}
+                placeholderEmail={email}
               />
 
             case 'dashboard':

--- a/src/userbase-server/admin-panel/App.jsx
+++ b/src/userbase-server/admin-panel/App.jsx
@@ -11,10 +11,13 @@ export default class App extends Component {
 
     this.state = {
       mode: undefined,
-      email: undefined
+      signedIn: undefined,
+      email: undefined,
+      fullName: undefined
     }
 
     this.handleSignOut = this.handleSignOut.bind(this)
+    this.handleUpdateAccount = this.handleUpdateAccount.bind(this)
     this.handleReadHash = this.handleReadHash.bind(this)
   }
 
@@ -31,14 +34,28 @@ export default class App extends Component {
     await adminLogic.signOut()
   }
 
+  handleUpdateAccount(email, fullName) {
+    this.setState({
+      email: email || this.state.email,
+      fullName: fullName || this.state.fullName
+    })
+  }
+
   handleReadHash() {
     const sessionJson = localStorage.getItem('adminSession')
     const session = sessionJson && JSON.parse(sessionJson)
     const signedIn = session && session.signedIn
     const email = session && session.email
+    const fullName = session && session.fullName
 
-    if (email && email !== this.state.email) {
-      this.setState({ email: session.email })
+    this.setState({ signedIn })
+
+    if (email !== this.state.email) {
+      this.setState({ email })
+    }
+
+    if (fullName !== this.state.fullName) {
+      this.setState({ fullName })
     }
 
     const hashRoute = window.location.hash.substring(1)
@@ -67,11 +84,14 @@ export default class App extends Component {
   }
 
   render() {
-    const { mode, email } = this.state
+    const { mode, signedIn, email, fullName } = this.state
 
     if (!mode) {
       return <div />
     }
+
+    const adminPanelHeader = signedIn && fullName
+      && `${fullName}'${fullName.charAt(fullName.length - 1) === "s" ? "" : "s"} `
 
     return (
       <div>
@@ -79,7 +99,7 @@ export default class App extends Component {
           <div className='flex-0 ml-2 tracking-tight'>
             <div className='flex items-center min-w-full'>
               <a href='#'><img src={require('./img/icon.png')} className='h-10 sm:h-12' /></a>
-              <p className='ml-4 italic'>Admin Panel</p>
+              <p className='ml-4 italic'>{adminPanelHeader || ''}Admin Panel</p>
             </div>
           </div>
           <div className='flex-1 text-right tracking-tight mr-5'>
@@ -122,7 +142,7 @@ export default class App extends Component {
               />
 
             case 'edit-account':
-              return <EditAdmin />
+              return <EditAdmin handleUpdateAccount={this.handleUpdateAccount} />
 
             default:
               return null

--- a/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
@@ -6,7 +6,7 @@ export default class AdminForm extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      adminName: this.props.placeholderAdminName,
+      email: this.props.placeholderEmail,
       password: '',
       fullName: '',
       error: '',
@@ -29,7 +29,7 @@ export default class AdminForm extends Component {
   }
   handleHitEnter(e) {
     const ENTER_KEY_CODE = 13
-    if ((e.target.name === 'adminName' || e.target.name === 'password') &&
+    if ((e.target.name === 'email' || e.target.name === 'password') &&
       (e.key === 'Enter' || e.keyCode === ENTER_KEY_CODE)) {
       e.stopPropagation()
     }
@@ -49,16 +49,16 @@ export default class AdminForm extends Component {
 
   async handleSubmit(event) {
     const { formType } = this.props
-    const { adminName, password, fullName } = this.state
+    const { email, password, fullName } = this.state
     event.preventDefault()
 
     this.setState({ loading: true })
 
     try {
       if (formType === 'Create Admin') {
-        await adminLogic.createAdmin(adminName, password, fullName)
+        await adminLogic.createAdmin(email, password, fullName)
       } else if (formType === 'Sign In') {
-        await adminLogic.signIn(adminName, password)
+        await adminLogic.signIn(email, password)
       } else {
         return console.error('Unknown form type')
       }
@@ -72,12 +72,12 @@ export default class AdminForm extends Component {
   async handleForgotPassword(event) {
     event.preventDefault()
 
-    const { adminName } = this.state
+    const { email } = this.state
 
     this.setState({ loading: true })
 
     try {
-      await adminLogic.forgotPassword(adminName)
+      await adminLogic.forgotPassword(email)
       window.alert('Check your email!')
       if (this._isMounted) this.setState({ loading: false })
     } catch (e) {
@@ -86,10 +86,10 @@ export default class AdminForm extends Component {
   }
 
   render() {
-    const { adminName, password, fullName, error, loading } = this.state
+    const { email, password, fullName, error, loading } = this.state
     const { formType } = this.props
 
-    const disabled = !adminName || !password || (formType === 'Create Admin' && (!fullName))
+    const disabled = !email || !password || (formType === 'Create Admin' && (!fullName))
 
     return (
       <form onSubmit={this.handleSubmit}>
@@ -123,11 +123,11 @@ export default class AdminForm extends Component {
               <div className='table-cell p-2'>
                 <input
                   className='font-light text-xs xs:text-sm w-48 sm:w-84 h-8 p-2 border border-gray-500 outline-none'
-                  type='text'
-                  name='adminName'
-                  autoComplete='username'
+                  type='email'
+                  name='email'
+                  autoComplete='email'
                   onChange={this.handleInputChange}
-                  defaultValue={adminName}
+                  defaultValue={email}
                 />
               </div>
             </div>
@@ -192,5 +192,5 @@ export default class AdminForm extends Component {
 
 AdminForm.propTypes = {
   formType: string,
-  placeholderAdminName: string
+  placeholderEmail: string
 }

--- a/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
@@ -1,57 +1,176 @@
 import React, { Component } from 'react'
+import { func } from 'prop-types'
 import adminLogic from './logic'
 
 export default class EditAdmin extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      error: '',
-      loading: false
+      email: '',
+      fullName: '',
+      password: '',
+      loadingUpdate: false,
+      loadingDelete: false,
+      errorUpdating: '',
+      errorDeleting: ''
     }
 
+    this.handleInputChange = this.handleInputChange.bind(this)
+    this.handleUpdateAcount = this.handleUpdateAcount.bind(this)
     this.handleDeleteAccount = this.handleDeleteAccount.bind(this)
   }
 
   componentDidMount() {
     this._isMounted = true
+    document.addEventListener('keydown', this.handleHitEnter, true)
   }
 
   componentWillUnmount() {
     this._isMounted = false
+    document.removeEventListener('keydown', this.handleHitEnter, true)
+  }
+
+  handleHitEnter(e) {
+    const ENTER_KEY_CODE = 13
+    if ((e.target.name === 'email' || e.target.name === 'password' || e.target.name === 'fullName') &&
+      (e.key === 'Enter' || e.keyCode === ENTER_KEY_CODE)) {
+      e.stopPropagation()
+    }
+  }
+
+  handleInputChange(event) {
+    if (this.state.errorUpdating || this.state.errorDeleting) {
+      this.setState({ errorUpdating: undefined, errorDeleting: undefined })
+    }
+
+    const target = event.target
+    const value = target.value
+    const name = target.name
+
+    this.setState({
+      [name]: value
+    })
+  }
+
+  async handleUpdateAcount(event) {
+    const { email, password, fullName } = this.state
+    event.preventDefault()
+
+    if (!email && !password && !fullName) return
+
+    this.setState({ loadingUpdate: true })
+
+    try {
+      await adminLogic.updateAdmin({ email, password, fullName })
+      if (email || fullName) this.props.handleUpdateAccount(email, fullName)
+      if (this._isMounted) this.setState({ email: '', password: '', fullName: '', loadingUpdate: false })
+    } catch (e) {
+      if (this._isMounted) this.setState({ errorUpdating: e.message, loadingUpdate: false })
+    }
   }
 
   async handleDeleteAccount(event) {
     event.preventDefault()
 
+    this.setState({ errorDeleting: '' })
+
     try {
       if (window.confirm('Are you sure you want to delete your account?')) {
-        this.setState({ loading: true })
+        this.setState({ loadingDelete: true })
         await adminLogic.deleteAdmin()
       }
     } catch (e) {
-      if (this._isMounted) this.setState({ error: e.message, loading: false })
+      if (this._isMounted) this.setState({ errorDeleting: e.message, loadingDelete: false })
     }
   }
 
   render() {
-    const { error, loading } = this.state
+    const { fullName, email, password, loadingUpdate, loadingDelete, errorUpdating, errorDeleting } = this.state
 
     return (
-      <div className='container content text-xs xs:text-base'>
+      <div className='container content text-xs xs:text-base text-center'>
 
-        <div className='text-center'>
-          <input
-            className='btn w-40'
-            type='button'
-            value={loading ? 'Deleting...' : 'Delete Account'}
-            disabled={loading}
-            onClick={this.handleDeleteAccount}
-          />
+        <form onSubmit={this.handleUpdateAcount}>
+          <div className='table'>
 
-          {error && <div className='error'>{error}</div>}
-        </div>
+            <div className='table-row'>
+              <div className='table-cell p-2 text-right'>Full Name</div>
+              <div className='table-cell p-2'>
+                <input
+                  className='font-light text-xs xs:text-sm w-48 sm:w-84 h-8 p-2 border border-gray-500 outline-none'
+                  type='text'
+                  name='fullName'
+                  autoComplete='name'
+                  value={fullName}
+                  onChange={this.handleInputChange}
+                />
+              </div>
+            </div>
+
+            <div className='table-row'>
+              <div className='table-cell p-2 text-right'>Email</div>
+              <div className='table-cell p-2'>
+                <input
+                  className='font-light text-xs xs:text-sm w-48 sm:w-84 h-8 p-2 border border-gray-500 outline-none'
+                  type='email'
+                  name='email'
+                  autoComplete='email'
+                  onChange={this.handleInputChange}
+                  value={email}
+                />
+              </div>
+            </div>
+
+            <div className='table-row'>
+              <div className='table-cell p-2 text-right'>Password</div>
+              <div className='table-cell p-2'>
+                <input
+                  className='font-light text-xs xs:text-sm w-48 sm:w-84 h-8 p-2 border border-gray-500 outline-none'
+                  type='password'
+                  name='password'
+                  autoComplete='new-password'
+                  onChange={this.handleInputChange}
+                  value={password}
+                />
+              </div>
+            </div>
+
+          </div>
+
+
+          <div className='mt-3 h-16'>
+            <div className='h-6 text-center'>
+              <input
+                className='btn w-40'
+                type='submit'
+                value={loadingUpdate ? 'Updating...' : 'Update Account'}
+                disabled={(!fullName && !email && !password) || loadingDelete || loadingUpdate}
+              />
+
+              <div className='error'>{errorUpdating}</div>
+            </div>
+
+          </div>
+
+        </form>
+
+        <hr className='border border-t-0 border-gray-400 mt-8 mb-4' />
+
+        <input
+          className='btn w-40'
+          type='button'
+          value={loadingDelete ? 'Deleting...' : 'Delete Account'}
+          disabled={loadingDelete}
+          onClick={this.handleDeleteAccount}
+        />
+
+        {errorDeleting && <div className='error'>{errorDeleting}</div>}
 
       </div>
     )
   }
+}
+
+EditAdmin.propTypes = {
+  handleUpdateAccount: func
 }

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -22,8 +22,8 @@ const handleSignOut = () => {
   window.location.hash = 'sign-in'
 }
 
-const signInLocalSession = (adminName) => {
-  const adminSession = JSON.stringify({ adminName, signedIn: true })
+const signInLocalSession = (email) => {
+  const adminSession = JSON.stringify({ email, signedIn: true })
   localStorage.setItem('adminSession', adminSession)
 }
 
@@ -38,20 +38,20 @@ const removeLocalSession = () => {
   localStorage.removeItem('adminSession')
 }
 
-const createAdmin = async (adminName, password, fullName) => {
+const createAdmin = async (email, password, fullName) => {
   try {
-    const lowerCaseAdminName = adminName.toLowerCase()
+    const lowerCaseEmail = email.toLowerCase()
     await axios({
       method: 'POST',
       url: `/${VERSION}/admin/create-admin`,
       data: {
-        adminName: lowerCaseAdminName,
+        email: lowerCaseEmail,
         password,
         fullName
       },
       timeout: TEN_SECONDS_MS
     })
-    signInLocalSession(lowerCaseAdminName)
+    signInLocalSession(lowerCaseEmail)
   } catch (e) {
     errorHandler(e)
   }
@@ -82,30 +82,30 @@ const signOut = async () => {
   })
 }
 
-const signIn = async (adminName, password) => {
+const signIn = async (email, password) => {
   try {
-    const lowerCaseAdminName = adminName.toLowerCase()
+    const lowerCaseEmail = email.toLowerCase()
     await axios({
       method: 'POST',
       url: `/${VERSION}/admin/sign-in`,
       data: {
-        adminName: lowerCaseAdminName,
+        email: lowerCaseEmail,
         password
       },
       timeout: TEN_SECONDS_MS
     })
-    signInLocalSession(lowerCaseAdminName)
+    signInLocalSession(lowerCaseEmail)
   } catch (e) {
     errorHandler(e, false)
   }
 }
 
-const forgotPassword = async (adminName) => {
+const forgotPassword = async (email) => {
   try {
-    const lowerCaseAdminName = adminName.toLowerCase()
+    const lowerCaseEmail = email.toLowerCase()
     await axios({
       method: 'POST',
-      url: `/${VERSION}/admin/forgot-password?adminName=${lowerCaseAdminName}`,
+      url: `/${VERSION}/admin/forgot-password?email=${lowerCaseEmail}`,
       timeout: TEN_SECONDS_MS
     })
   } catch (e) {

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -255,6 +255,7 @@ async function start(express, app, userbaseConfig = {}) {
     v1.post('/admin/delete-app', admin.authenticateAdmin, appController.deleteApp)
     v1.post('/admin/delete-user', admin.authenticateAdmin, admin.deleteUser)
     v1.post('/admin/delete-admin', admin.authenticateAdmin, admin.deleteAdmin)
+    v1.post('/admin/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1.post('/admin/forgot-password', admin.forgotPassword)
 
     app.get('/ping', function (req, res) {
@@ -266,8 +267,8 @@ async function start(express, app, userbaseConfig = {}) {
   }
 }
 
-function createAdmin(email, password, adminId, storePasswordInSecretsManager = false) {
-  return admin.createAdmin(email, password, adminId, storePasswordInSecretsManager)
+function createAdmin(email, password, fullName, adminId, storePasswordInSecretsManager = false) {
+  return admin.createAdmin(email, password, fullName, adminId, storePasswordInSecretsManager)
 }
 
 function createApp(appName, adminId, appId) {

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -266,8 +266,8 @@ async function start(express, app, userbaseConfig = {}) {
   }
 }
 
-function createAdmin(adminName, password, adminId, storePasswordInSecretsManager = false) {
-  return admin.createAdmin(adminName, password, adminId, storePasswordInSecretsManager)
+function createAdmin(email, password, adminId, storePasswordInSecretsManager = false) {
+  return admin.createAdmin(email, password, adminId, storePasswordInSecretsManager)
 }
 
 function createApp(appName, adminId, appId) {

--- a/src/userbase-server/setup.js
+++ b/src/userbase-server/setup.js
@@ -114,11 +114,11 @@ async function setupDdb() {
     TableName: adminTableName,
     BillingMode: 'PAY_PER_REQUEST',
     AttributeDefinitions: [
-      { AttributeName: 'admin-name', AttributeType: 'S' },
+      { AttributeName: 'email', AttributeType: 'S' },
       { AttributeName: 'admin-id', AttributeType: 'S' }
     ],
     KeySchema: [
-      { AttributeName: 'admin-name', KeyType: 'HASH' }
+      { AttributeName: 'email', KeyType: 'HASH' }
     ],
     GlobalSecondaryIndexes: [{
       IndexName: adminIdIndex,


### PR DESCRIPTION
- Refactored "adminName" to "email" & validate emails on admin account creation and update server-side
- if admin updates email, server creates new DDB item and deletes old one inside a DDB tx
- client keeps admin's full name in local storage
- full name now must be provided to createAdmin endpoint

![UpdateAdmin](https://user-images.githubusercontent.com/26468430/70579229-cdb39780-1b64-11ea-923e-9aab68339836.gif)