### PR TITLE
Db optimizations

### DIFF
--- a/src/userbase-js/db.js
+++ b/src/userbase-js/db.js
@@ -58,7 +58,7 @@ class UnverifiedTransaction {
       this.promiseResolve = resolve
       this.promiseReject = reject
 
-      setTimeout(() => { reject(new Error('timeout')) }, 5000)
+      setTimeout(() => { reject(new Error('timeout')) }, 10000)
     })
 
     this.verifyPromise()

--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -193,7 +193,7 @@ const putTransaction = async function (transaction, userId, dbNameHash, database
   }
 
   // notify all websocket connections that there's a database change
-  connections.push(transaction['database-id'], userId)
+  connections.push(transaction, userId)
 
   return transaction['sequence-no']
 }

--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -171,7 +171,7 @@ const putTransaction = async function (transaction, userId, dbNameHash, database
     transaction['sequence-no'] = db.Attributes['next-seq-number']
     transaction['creation-date'] = new Date().toISOString()
   } catch (e) {
-    throw new Error(`Failed with ${e}.`)
+    throw new Error(`Failed to increment sequence number with ${e}.`)
   }
 
   // write the transaction using the next sequence number
@@ -189,7 +189,7 @@ const putTransaction = async function (transaction, userId, dbNameHash, database
   } catch (e) {
     // best effort rollback - if the rollback fails here, it will get attempted again when the transactions are read
     await rollbackAttempt(transaction, ddbClient)
-    throw new Error(`Failed with ${e}.`)
+    throw new Error(`Failed to put transaction with ${e}.`)
   }
 
   // notify all websocket connections that there's a database change
@@ -216,7 +216,7 @@ const rollbackAttempt = async function (transaction, ddbClient) {
   try {
     await ddbClient.put(rollbackParams).promise()
   } catch (e) {
-    throw new Error(`Failed with ${e}.`)
+    throw new Error(`Failed to rollback with ${e}.`)
   }
 }
 


### PR DESCRIPTION
As discussed:

### [Support higher concurrency](https://github.com/encrypted-dev/userbase/commit/ab9b6be71e56fe7963ce8df79504a484e9e53385)

Allow a 10s buffer before triggering rollbacks upon finding a gap in DDB tx sequence numbers. Tested 1000 concurrent insertions (needed to raise [this timeout](https://github.com/encrypted-dev/userbase/compare/db-optimizations?expand=1#diff-94758e067438af2615c1d97a0f1c3d0fR61) for 1000 concurrent txs to finish on my machine)

### [Reduce avg. tx latency](https://github.com/encrypted-dev/userbase/commit/f8f3263f024a618189b5c81c5c123f7b12c87133)

"Currently we're writing a tx to DDB, and then we read the tx back from DDB to push it to the client over the WS. In theory, if the new tx's seq # is adjacent to the last seq # stored in the WS's state, we could just push the tx we've just written to the WS. No need to read it from DDB (since it's immutable, and nobody could have added a tx with that seq #)."

- @dvassallo 