### PR TITLE
Fix: database reopens on websocket reconnect

### DIFF
--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -110,18 +110,22 @@ const getDatabase = async function (userId, dbNameHash) {
 
 exports.openDatabase = async function (userId, connectionId, dbNameHash, newDatabaseParams) {
   if (!dbNameHash) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database name hash')
-  if (!newDatabaseParams) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing new database params')
-
-  const newDbId = newDatabaseParams.dbId
-  const { encryptedDbName, encryptedDbKey } = newDatabaseParams
-  if (!newDbId) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database id')
-  if (!encryptedDbName) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database name')
-  if (!encryptedDbKey) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database key')
 
   try {
     let database
     try {
-      database = await getDatabase(userId, dbNameHash) || await createDatabase(userId, dbNameHash, newDbId, encryptedDbName, encryptedDbKey)
+      database = await getDatabase(userId, dbNameHash)
+
+      if (!database && !newDatabaseParams) return responseBuilder.errorResponse(statusCodes['Not Found'], 'Database not found')
+      else if (!database) {
+        // attempt to create new database
+        const { dbId, encryptedDbName, encryptedDbKey } = newDatabaseParams
+        if (!dbId) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database id')
+        if (!encryptedDbName) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database name')
+        if (!encryptedDbKey) return responseBuilder.errorResponse(statusCodes['Bad Request'], 'Missing database key')
+
+        database = await createDatabase(userId, dbNameHash, dbId, encryptedDbName, encryptedDbKey)
+      }
     } catch (e) {
       if (e.data === 'Database already exists' || e.data === 'Database already creating') {
         // User must have made a concurrent request to open db with same name for the first time.


### PR DESCRIPTION
- Accidentally broke this when rolling createDatabase up into openDatabase server-side
- When rolling createDatabase up into openDatabase server-side, I made the server enforce that the client pass the parameter `newDatabaseParams` to openDatabase. However, when re-opening the database, this param isn't necessary because we know the server shouldn't need to create a new database if one isn't found
- This fix removes the requirement to pass `newDatabaseParams` to the server when calling openDatabase so that when the client attempts to reopen a database after reconnecting the websocket, the client can do so without providing anything to `newDatabaseParams`