### PR TITLE
Fix: Ensure we correctly estimate the size of DDB items for Userbase transactions

### DIFF
--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -18,7 +18,9 @@ export const validateEmail = (email) => {
   return true
 }
 
-export const sizeOfDdbItem = (item) => {
+// estimates the size of a DDB item that we know will be structured a certain way. This
+// will not work for arbitrary DDB items that have different data types we are not using
+export const estimateSizeOfDdbItem = (item) => {
   let bytes = 0
 
   for (let attribute in item) {
@@ -37,6 +39,12 @@ export const sizeOfDdbItem = (item) => {
         break
       case 'boolean':
         bytes += 1 // The size of a null attribute or a Boolean attribute is(length of attribute name) + (1 byte).
+        break
+      case 'object':
+        bytes += 3 // An attribute of type List or Map requires 3 bytes of overhead, regardless of its contents
+        for (let objectItem of value) {
+          bytes += estimateSizeOfDdbItem(objectItem)
+        }
         break
       default:
         if (value.type === 'Buffer') {

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -3,7 +3,7 @@ import setup from './setup'
 import uuidv4 from 'uuid/v4'
 import db from './db'
 import logger from './logger'
-import { sizeOfDdbItem } from './utils'
+import { estimateSizeOfDdbItem } from './utils'
 
 const SECONDS_BEFORE_ROLLBACK_GAP_TRIGGERED = 1000 * 10 // 10s
 const TRANSACTION_SIZE_BUNDLE_TRIGGER = 1024 * 50 // 50 KB
@@ -80,7 +80,7 @@ class Connection {
         let transactionLogResponse = await ddbClient.query(params).promise()
 
         for (let i = 0; i < transactionLogResponse.Items.length && !gapInSeqNo; i++) {
-          size += sizeOfDdbItem(transactionLogResponse.Items[i])
+          size += estimateSizeOfDdbItem(transactionLogResponse.Items[i])
 
           // if there's a gap in sequence numbers and past rollback buffer, rollback all transactions in gap
           gapInSeqNo = transactionLogResponse.Items[i]['sequence-no'] > lastSeqNo + 1
@@ -241,7 +241,7 @@ export default class Connections {
           dbId: transaction['database-id']
         }
 
-        conn.sendPayload(payload, database, sizeOfDdbItem(transaction))
+        conn.sendPayload(payload, database, estimateSizeOfDdbItem(transaction))
       } else {
         conn.push(transaction['database-id'])
       }


### PR DESCRIPTION
- When calculating the size of a Userbase transaction's DDB item, the operations array was ignored and thus not triggering the bundling process
- Also made it clearer the function to get the size of a DDB item is an estimate