### PR TITLE
Fix: bundling process working consistently

### DIFF
--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -317,7 +317,7 @@ exports.bundleTransactionLog = async function (databaseId, seqNo, bundle) {
     const s3 = setup.s3()
     await s3.upload(dbStateParams).promise()
 
-    logger.info('Setting bundle sequence number on user...')
+    logger.info(`Setting bundle sequence number ${bundleSeqNo} on database ${databaseId}...`)
 
     const bundleParams = {
       TableName: setup.databaseTableName,
@@ -339,8 +339,8 @@ exports.bundleTransactionLog = async function (databaseId, seqNo, bundle) {
 
     return responseBuilder.successResponse({})
   } catch (e) {
-
-    return responseBuilder.errorResponse(statusCodes['Internal Server Error'], `Failed to bundle with ${e}`)
+    logger.error(`Failed to bundle database ${databaseId} at sequence number ${bundleSeqNo} with ${e}`)
+    return responseBuilder.errorResponse(statusCodes['Internal Server Error'], 'Failed to bundle')
   }
 }
 


### PR DESCRIPTION
### Bug 1

When a bundle was stored for a user, the backend wasn't reading the bundle as expected (was getting transactions from DDB)

Fixed by getting bundle when [database.lastSeqNo === 0](https://github.com/encrypted-dev/userbase/pull/45/files#diff-c6842224b01f98a47fa1890c0e3842d3R50)

### Bug 2

Race condition in the client between ApplyTransactions and BuildBundle. BuildBundle would sometimes run before ApplyTransactions finishes and the bundle sent to the server would be empty

Fixed by removing the 'BuildBundle' route and adding a [buildBundle boolean](https://github.com/encrypted-dev/userbase/pull/45/files#diff-c6842224b01f98a47fa1890c0e3842d3R157) to 'ApplyTransactions' payload so the client will always build the bundle after transactions are applied