### PR TITLE
Fix: insert/update/delete do not return until changeHandler called

### DIFF
--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -304,12 +304,12 @@ class Connection {
 
         const newTransactions = message.transactionLog
         await database.applyTransactions(newTransactions)
-        database.onChange(database.getItems())
 
         if (!database.init) {
           this.state.dbIdToHash[dbId] = dbNameHash
           database.dbId = dbId
           database.init = true
+          database.receivedMessage()
         }
 
         if (message.buildBundle) {


### PR DESCRIPTION
### The Issue

The `changeHandler` was getting called [AFTER all transactions were applied](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/ws.js#L306-L307). This meant in a situation where a user attempts concurrent inserts, an insert could _sometimes_ resolve and return to the user BEFORE the `changeHandler` gets called.

This caused the test4 failure highlighted in PR #48

Here's the circumstance described:

1. Browser 1 inserts item foo [placing it in the array of unverified tx’s, then queues request()](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/db.js#L689-L699)
2. Browser 2 inserts item bar
3. Browser 1 receives transaction log with foo and bar and [applies this log](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/ws.js#L306)
4. Browser 1 successfully [applies and resolves foo promise, then iterates in the for loop and queues the promise to apply bar](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/db.js#L118-L131)
5. Browser 1 [receives response to request(), finishes executing the transaction and returns `insertItem(foo)` to the user](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/db.js#L702)
6. Browser 1 finishes applying bar **then finally** [calls the changeHandler with foo and bar in the state](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/ws.js#L307)

### The fix

With the approach in this PR, steps 1-3 are the same, but the latter steps look like this:

4. Browser 1 successfully applies and resolves foo promise, then [calls the changeHandler with foo in the state](https://github.com/encrypted-dev/userbase/blob/b921c1917e8e805a7532615d6d13c9c6177a4248/src/userbase-js/src/db.js#L133-L135)
5. Browser 1 receives response to request(), finishes executing the transaction and returns `insertItem(foo)` to the user
6. Browser 1 finishes applying bar then [calls the changeHandler again with bar in the state]((https://github.com/encrypted-dev/userbase/blob/b921c1917e8e805a7532615d6d13c9c6177a4248/src/userbase-js/src/db.js#L133-L135))

Note that if a transaction is successful, the [getResult() promise](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/db.js#L702) will resolve, but the changeHandler [will continue executing synchronously](https://github.com/encrypted-dev/userbase/blob/b921c1917e8e805a7532615d6d13c9c6177a4248/src/userbase-js/src/db.js#L130-L135). The original [postTransaction()](https://github.com/encrypted-dev/userbase/blob/4162cf97cca0f7a95553e62a1c0d8b01fdd89438/src/userbase-js/src/db.js#L702-L706) won't continue executing until the `changeHandler` finishes executing. 

Thus, in simpler terms, whenever a user calls `insertItem()` and it returns, the user is guaranteed to have seen the inserted item in their db change handler (same logic applies to `deleteItem()`, `updateItem()`, and `transaction()`).

#### An important note

As pointed out in a similar circumstance by @adaddeo a while back, the following circumstance is possible:
- a developer renders a loader before calling `insertItem()`
- then while the **loader** is _still_ rendered, the **item** renders because their changeHandler executes
- then `insertItem()` resolves and the developer stops rendering the loader

So the item could be rendered while the loader is still on the screen.

Note that this was the case before this PR as well. This PR simply makes the behavior consistent (the db change handler is now **guaranteed** to have been called before `insertItem()` returns, rather than **usually** getting called before `insertItem()` returns).

#### Minor note

I also got rid of the `handlerWrapper` in favor of just using the `receivedMessage` promise in a more obvious place.