### PR TITLE
Db correctness changes

### DIFF
--- a/src/userbase-js/src/config.js
+++ b/src/userbase-js/src/config.js
@@ -1,9 +1,10 @@
 import errors from './errors'
 
 const VERSION = '/v1'
+const DEFAULT_ENDPOINT = 'https://preview.userbase.dev' + VERSION
 
 let userbaseAppId = null
-let userbaseEndpoint = 'https://preview.userbase.dev' + VERSION
+let userbaseEndpoint = DEFAULT_ENDPOINT
 let userbaseKeyNotFoundHandler = null
 
 const getAppId = () => {
@@ -16,6 +17,7 @@ const getEndpoint = () => userbaseEndpoint
 const getKeyNotFoundHandler = () => userbaseKeyNotFoundHandler
 
 const setAppId = (appId) => {
+  if (userbaseAppId && userbaseAppId !== appId) throw new errors.AppIdAlreadySet(userbaseAppId)
   if (typeof appId !== 'string') throw new errors.AppIdMustBeString
   if (appId.length === 0) throw new errors.AppIdCannotBeBlank
   userbaseAppId = appId
@@ -23,11 +25,14 @@ const setAppId = (appId) => {
 
 const setEndpoint = (newEndpoint) => {
   if (!newEndpoint) return
+  if (userbaseEndpoint !== DEFAULT_ENDPOINT && newEndpoint + VERSION !== userbaseEndpoint) {
+    throw new errors.EndpointAlreadySet(userbaseEndpoint)
+  }
   userbaseEndpoint = newEndpoint + VERSION
 }
 
 const setKeyNotFoundHandler = (keyNotFoundHandler) => {
-  if (keyNotFoundHandler && typeof keyNotFoundHandler !== 'function') {
+  if (keyNotFoundHandler !== undefined && typeof keyNotFoundHandler !== 'function') {
     throw new errors.KeyNotFoundHandlerMustBeFunction
   }
   userbaseKeyNotFoundHandler = keyNotFoundHandler

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -4,7 +4,7 @@ import crypto from './Crypto'
 import ws from './ws'
 import errors from './errors'
 import statusCodes from './statusCodes'
-import { byteSizeOfString } from './utils'
+import { byteSizeOfString, Queue } from './utils'
 
 const success = 'Success'
 
@@ -109,10 +109,13 @@ class Database {
 
     this.itemsIndex = new SortedArray([], compareItems)
     this.unverifiedTransactions = []
-    this.lastSeqNo = -1
+    this.lastSeqNo = 0
     this.init = false
-    this.receivedMessage = receivedMessage
     this.dbKey = null
+    this.receivedMessage = receivedMessage
+
+    // Queue that ensures 'ApplyTransactions' executes one at a time
+    this.applyTransactionsQueue = new Queue()
   }
 
   async applyTransactions(transactions) {
@@ -229,6 +232,16 @@ class Database {
         }
 
         return this.applyBatchTransaction(seqNo, batch, records)
+      }
+
+      case 'Rollback': {
+        // no-op
+        return
+      }
+
+      default: {
+        console.warn(`Unknown command: ${command}`)
+        return
       }
     }
   }
@@ -358,20 +371,43 @@ class Database {
 
 const _openDatabase = async (dbNameHash, changeHandler, newDatabaseParams) => {
   try {
-    if (ws.state.databases[dbNameHash] && ws.state.databases[dbNameHash].init) {
-      throw new errors.DatabaseAlreadyOpen
-    } else if (ws.state.databases[dbNameHash]) {
-      throw new errors.DatabaseAlreadyOpening
+    const database = ws.state.databases[dbNameHash]
+
+    // cannot attempt to open database that's already initialized while transactions are being applied.
+    // this can happen if initial request times out while transactions are applying and user attempts
+    // to retry call to openDatabase. Should happen very rarely and safe for user to try again
+    if (database && !database.applyTransactionsQueue.isEmpty()) {
+      throw new errors.ServiceUnavailable
     }
 
     let receivedMessage
 
     const firstMessageFromWebSocket = new Promise((resolve, reject) => {
       receivedMessage = resolve
-      setTimeout(() => reject(new Error('timeout')), 5000)
+      setTimeout(() => reject(new Error('timeout')), 20000)
     })
 
-    ws.state.databases[dbNameHash] = new Database(changeHandler, receivedMessage)
+    if (!database) {
+      ws.state.databases[dbNameHash] = new Database(changeHandler, receivedMessage)
+    } else {
+
+      // safe to replace -- enables idempotent calls to openDatabase
+      database.onChange = changeHandler
+
+      // if 1 call succeeds, all idempotent calls succeed
+      const currentReceivedMessage = database.receivedMessage
+      database.receivedMessage = () => {
+        currentReceivedMessage()
+        receivedMessage()
+      }
+
+      // database is already open, can return successfully
+      if (database.init) {
+        changeHandler(database.getItems())
+        database.receivedMessage()
+        return
+      }
+    }
 
     const action = 'OpenDatabase'
     const params = { dbNameHash, newDatabaseParams }
@@ -380,8 +416,6 @@ const _openDatabase = async (dbNameHash, changeHandler, newDatabaseParams) => {
       await ws.request(action, params)
       await firstMessageFromWebSocket
     } catch (e) {
-      delete ws.state.databases[dbNameHash]
-
       if (e.response && e.response.data === 'Database already creating') {
         throw new errors.DatabaseAlreadyOpening
       }
@@ -437,7 +471,6 @@ const openDatabase = async (dbName, changeHandler) => {
   } catch (e) {
 
     switch (e.name) {
-      case 'DatabaseAlreadyOpen':
       case 'DatabaseAlreadyOpening':
       case 'DatabaseNameMustBeString':
       case 'DatabaseNameCannotBeBlank':

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -120,6 +120,12 @@ class Database {
       const transaction = transactions[i]
       const seqNo = transaction.seqNo
 
+      // client must only apply transcations in sequence
+      if (seqNo !== this.lastSeqNo + 1) {
+        console.warn(`Client attempted to apply transaction with seq no ${seqNo} when last seq no is ${this.lastSeqNo}`)
+        continue
+      }
+
       const transactionCode = await this.applyTransaction(this.dbKey, transaction)
       this.lastSeqNo = seqNo
 
@@ -141,6 +147,12 @@ class Database {
   }
 
   applyBundle(bundle, bundleSeqNo) {
+    // client must only apply bundle when opening state
+    if (this.lastSeqNo !== 0) {
+      console.warn(`Client attempted to apply bundle when last seq no is ${this.lastSeqNo}`)
+      return
+    }
+
     for (let i = 0; i < bundle.itemsIndex.length; i++) {
       const itemIndex = bundle.itemsIndex[i]
       const itemId = bundle.itemsIndex[i].itemId

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -373,13 +373,6 @@ const _openDatabase = async (dbNameHash, changeHandler, newDatabaseParams) => {
   try {
     const database = ws.state.databases[dbNameHash]
 
-    // cannot attempt to open database that's already initialized while transactions are being applied.
-    // this can happen if initial request times out while transactions are applying and user attempts
-    // to retry call to openDatabase. Should happen very rarely and safe for user to try again
-    if (database && !database.applyTransactionsQueue.isEmpty()) {
-      throw new errors.ServiceUnavailable
-    }
-
     let receivedMessage
 
     const firstMessageFromWebSocket = new Promise((resolve, reject) => {

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -239,16 +239,6 @@ class ProfileValueTooLong extends Error {
   }
 }
 
-class KeyNotFoundHandlerMustBeFunction extends Error {
-  constructor(...params) {
-    super(...params)
-
-    this.name = 'KeyNotFoundHandlerMustBeFunction'
-    this.message = 'Key not found handler must be a function.'
-    this.status = statusCodes['Bad Request']
-  }
-}
-
 class KeyNotValid extends Error {
   constructor(username, ...params) {
     super(username, ...params)
@@ -334,7 +324,6 @@ export default {
   ProfileKeyTooLong,
   ProfileValueMustBeString,
   ProfileValueTooLong,
-  KeyNotFoundHandlerMustBeFunction,
   KeyNotValid,
   KeyCannotBeBlank,
   KeyMustBeString,

--- a/src/userbase-js/src/errors/config.js
+++ b/src/userbase-js/src/errors/config.js
@@ -1,5 +1,16 @@
 import statusCodes from '../statusCodes'
 
+class AppIdAlreadySet extends Error {
+  constructor(appId, ...params) {
+    super(appId, ...params)
+
+    this.name = 'AppIdAlreadySet'
+    this.message = 'Application ID already set.'
+    this.status = statusCodes['Conflict']
+    this.appId = appId
+  }
+}
+
 class AppIdMustBeString extends Error {
   constructor(...params) {
     super(...params)
@@ -19,7 +30,31 @@ class AppIdCannotBeBlank extends Error {
   }
 }
 
+class EndpointAlreadySet extends Error {
+  constructor(endpoint, ...params) {
+    super(endpoint, ...params)
+
+    this.name = 'EndpointAlreadySet'
+    this.message = 'Endpoint already set.'
+    this.status = statusCodes['Conflict']
+    this.endpoint = endpoint
+  }
+}
+
+class KeyNotFoundHandlerMustBeFunction extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'KeyNotFoundHandlerMustBeFunction'
+    this.message = 'Key not found handler must be a function.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 export default {
+  AppIdAlreadySet,
   AppIdMustBeString,
   AppIdCannotBeBlank,
+  EndpointAlreadySet,
+  KeyNotFoundHandlerMustBeFunction,
 }

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -30,16 +30,6 @@ class DatabaseNameTooLong extends Error {
   }
 }
 
-class DatabaseAlreadyOpen extends Error {
-  constructor(...params) {
-    super(...params)
-
-    this.name = 'DatabaseAlreadyOpen'
-    this.message = 'Database is already open.'
-    this.status = statusCodes['Bad Request']
-  }
-}
-
 class DatabaseAlreadyOpening extends Error {
   constructor(...params) {
     super(...params)
@@ -194,7 +184,6 @@ export default {
   DatabaseNameCannotBeBlank,
   DatabaseNameMustBeString,
   DatabaseNameTooLong,
-  DatabaseAlreadyOpen,
   DatabaseAlreadyOpening,
   ChangeHandlerMustBeFunction,
   DatabaseNotOpen,

--- a/src/userbase-js/src/statusCodes.js
+++ b/src/userbase-js/src/statusCodes.js
@@ -8,5 +8,12 @@ export default {
 
   'Internal Server Error': 500,
   'Service Unavailable': 503,
-  'Gateway Timeout': 504
+  'Gateway Timeout': 504,
+
+  // WebSocket close event codes
+  'Service Restart': 1012,
+
+  // Custom ws close event codes
+  'No Pong Received': 3000,
+  'Client Already Connected': 3001
 }

--- a/src/userbase-js/src/utils.js
+++ b/src/userbase-js/src/utils.js
@@ -34,3 +34,35 @@ export const byteSizeOfString = (string) => {
 export const objectHasOwnProperty = (object, property) => {
   return Object.prototype.hasOwnProperty.call(object, property)
 }
+
+// source: http://code.iamkate.com/javascript/queues
+export function Queue() {
+  let queue = []
+  let offset = 0
+
+  this.getLength = () => queue.length - offset
+
+  this.isEmpty = () => queue.length === 0
+
+  this.enqueue = (item) => {
+    queue.push(item)
+    return this.getLength()
+  }
+
+  this.dequeue = () => {
+    // get item from front of the queue
+    const item = queue[offset]
+
+    offset += 1
+
+    // garbage collect unused space in queue when it grows large
+    if (offset * 2 > queue.length) {
+      queue = queue.slice(offset)
+      offset = 0
+    }
+
+    return item
+  }
+
+  this.peek = () => queue[offset]
+}

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -15,9 +15,6 @@ const wsAlreadyConnected = 'Web Socket already connected'
 const BACKOFF_RETRY_DELAY = 1000
 const MAX_RETRY_DELAY = 1000 * 30
 
-const SERVICE_RESTART = 1012
-const NO_PONG_RECEIVED = 3000
-
 const clientId = uuidv4() // only 1 client ID per browser tab (assumes code does not reload)
 
 class RequestFailed extends Error {
@@ -46,7 +43,7 @@ class Connection {
     this.init()
   }
 
-  init(resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe, backUpKey) {
+  init(resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe, backUpKey, state) {
     if (this.pingTimeout) clearTimeout(this.pingTimeout)
 
     for (const property of Object.keys(this)) {
@@ -79,14 +76,14 @@ class Connection {
     this.processingSeedRequest = {}
     this.sentSeedTo = {}
 
-    this.state = {
+    this.state = state || {
       databases: {},
       dbIdToHash: {},
       dbNameToHash: {}
     }
   }
 
-  connect(appId, sessionId, username, seedString = null, rememberMe = false, backUpKey = true, reconnectDelay) {
+  connect(appId, sessionId, username, seedString = null, rememberMe = false, backUpKey = true, reconnectDelay, state) {
     if (this.connected) throw new WebSocketError(wsAlreadyConnected, this.username)
 
     return new Promise((resolve, reject) => {
@@ -94,7 +91,7 @@ class Connection {
 
       const timeoutToOpenWebSocket = setTimeout(
         () => {
-          if (!this.connected) {
+          if (!this.connected && !this.reconnecting) {
             timeout = true
             reject(new WebSocketError('timeout'))
           }
@@ -112,26 +109,169 @@ class Connection {
       ws.onopen = async () => {
         if (timeout) return
         clearTimeout(timeoutToOpenWebSocket)
-
-        if (this.connected) {
-          reject(new WebSocketError(wsAlreadyConnected, username))
-          return
-        }
-
-        this.init(resolve, reject, username, sessionId, seedString, rememberMe, backUpKey)
-        this.ws = ws
-        this.heartbeat()
-
-        if (!seedString) {
-          await this.requestSeed(username)
-        }
       }
 
       ws.onmessage = async (e) => {
         if (timeout) return
 
         try {
-          await this.handleMessage(JSON.parse(e.data))
+          const message = JSON.parse(e.data)
+          const route = message.route
+
+          switch (route) {
+            case 'Ping': {
+              this.heartbeat()
+
+              const action = 'Pong'
+              this.ws.send(JSON.stringify({ action }))
+              break
+            }
+
+            case 'Connection': {
+              this.init(resolve, reject, username, sessionId, seedString, rememberMe, backUpKey, state)
+              this.ws = ws
+              this.heartbeat()
+              this.connected = true
+
+              const {
+                salts,
+                encryptedValidationMessage
+              } = message
+
+              this.keys.salts = salts
+              this.encryptedValidationMessage = new Uint8Array(encryptedValidationMessage.data)
+
+              if (seedString) {
+                await this.setKeys(this.seedString)
+              } else {
+                await this.requestSeed(username)
+              }
+
+              break
+            }
+
+            case 'ApplyTransactions': {
+              const dbId = message.dbId
+              const dbNameHash = message.dbNameHash || this.state.dbIdToHash[dbId]
+              const database = this.state.databases[dbNameHash]
+
+              if (!database) throw new Error('Missing database')
+
+              // queue guarantees transactions will be applied in the order they are received from the server
+              if (database.applyTransactionsQueue.isEmpty()) {
+
+                // take a spot in the queue and proceed applying so the next caller knows queue is not empty
+                database.applyTransactionsQueue.enqueue(null)
+              } else {
+
+                // wait until prior batch in queue finishes applying successfully
+                await new Promise(resolve => {
+                  const startApplyingThisBatchOfTransactions = resolve
+                  database.applyTransactionsQueue.enqueue(startApplyingThisBatchOfTransactions)
+                })
+              }
+
+              const openingDatabase = message.dbNameHash && message.dbKey
+              if (openingDatabase) {
+                const dbKeyString = await crypto.aesGcm.decryptString(this.keys.encryptionKey, message.dbKey)
+                database.dbKeyString = dbKeyString
+                database.dbKey = await crypto.aesGcm.getKeyFromKeyString(dbKeyString)
+              }
+
+              if (!database.dbKey) throw new Error('Missing db key')
+
+              if (message.bundle) {
+                const bundleSeqNo = message.bundleSeqNo
+                const base64Bundle = message.bundle
+                const compressedString = await crypto.aesGcm.decryptString(database.dbKey, base64Bundle)
+                const plaintextString = LZString.decompress(compressedString)
+                const bundle = JSON.parse(plaintextString)
+
+                database.applyBundle(bundle, bundleSeqNo)
+              }
+
+              const newTransactions = message.transactionLog
+              await database.applyTransactions(newTransactions)
+
+              if (!database.init) {
+                this.state.dbIdToHash[dbId] = dbNameHash
+                database.dbId = dbId
+                database.init = true
+                database.receivedMessage()
+              }
+
+              if (message.buildBundle) {
+                this.buildBundle(database)
+              }
+
+              // start applying next batch in queue when this one is finished applying successfully
+              database.applyTransactionsQueue.dequeue()
+              if (!database.applyTransactionsQueue.isEmpty()) {
+                const startApplyingNextBatchInQueue = database.applyTransactionsQueue.peek()
+                startApplyingNextBatchInQueue()
+              }
+
+              break
+            }
+
+            case 'ReceiveRequestForSeed': {
+              if (!this.keys.init) return
+
+              const requesterPublicKey = message.requesterPublicKey
+              this.sendSeed(requesterPublicKey)
+
+              break
+            }
+
+            case 'ReceiveSeed': {
+              const { encryptedSeed, senderPublicKey } = message
+              const { seedRequestPrivateKey } = this.seedRequest
+
+              await this.receiveSeed(
+                encryptedSeed,
+                senderPublicKey,
+                seedRequestPrivateKey
+              )
+
+              break
+            }
+
+            case 'SignOut':
+            case 'UpdateUser':
+            case 'DeleteUser':
+            case 'CreateDatabase':
+            case 'GetDatabase':
+            case 'OpenDatabase':
+            case 'Insert':
+            case 'Update':
+            case 'Delete':
+            case 'BatchTransaction':
+            case 'Bundle':
+            case 'ValidateKey':
+            case 'RequestSeed':
+            case 'GetRequestsForSeed':
+            case 'SendSeed': {
+              const requestId = message.requestId
+
+              if (!requestId) return console.warn('Missing request id')
+
+              const request = this.requests[requestId]
+              if (!request) return console.warn(`Request ${requestId} no longer exists!`)
+              else if (!request.promiseResolve || !request.promiseReject) return
+
+              const response = message.response
+
+              const successfulResponse = response && response.status === statusCodes['Success']
+
+              if (!successfulResponse) return request.promiseReject(response)
+              else return request.promiseResolve(response)
+            }
+
+            default: {
+              console.log('Received unknown message from backend:' + JSON.stringify(message))
+              break
+            }
+          }
         } catch (e) {
           if (!this.connectionResolved) {
             this.close()
@@ -145,8 +285,8 @@ class Connection {
       ws.onclose = async (e) => {
         if (timeout) return
 
-        const serviceRestart = e.code === SERVICE_RESTART
-        const clientDisconnected = e.code === NO_PONG_RECEIVED
+        const serviceRestart = e.code === statusCodes['Service Restart']
+        const clientDisconnected = e.code === statusCodes['No Pong Received']
         const attemptToReconnect = serviceRestart || clientDisconnected || !e.wasClean // closed without explicit call to ws.close()
 
         if (attemptToReconnect) {
@@ -155,7 +295,9 @@ class Connection {
             : (reconnectDelay ? reconnectDelay + BACKOFF_RETRY_DELAY : 1000)
 
           this.reconnecting = true
-          await this.reconnect(appId, resolve, reject, username, sessionId, seedString, rememberMe, backUpKey, delay)
+          await this.reconnect(appId, resolve, reject, username, sessionId, seedString, rememberMe, backUpKey, delay, !this.reconnected && state)
+        } else if (e.code === statusCodes['Client Already Connected']) {
+          reject(new WebSocketError(wsAlreadyConnected, username))
         } else {
           this.init()
         }
@@ -163,15 +305,18 @@ class Connection {
     })
   }
 
-  async reconnect(appId, resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe, backUpKey, reconnectDelay) {
+  async reconnect(appId, resolveConnection, rejectConnection, username, sessionId, seedString, rememberMe, backUpKey, reconnectDelay, currentState) {
     try {
       const retryDelay = Math.min(reconnectDelay, MAX_RETRY_DELAY)
       console.log(`Connection to server lost. Attempting to reconnect in ${retryDelay / 1000} second${retryDelay !== 1000 ? 's' : ''}...`)
 
+      const dbsToReopen = []
+
+      // as soon as one reconnect succeeds, resolves all the way up the stack and all reconnects succeed
       resolveConnection(await new Promise((resolve, reject) => setTimeout(
         async () => {
           try {
-            const state = {
+            const state = currentState || {
               databases: { ...this.state.databases },
               dbIdToHash: { ...this.state.dbIdToHash },
               dbNameToHash: { ...this.state.dbNameToHash }
@@ -179,15 +324,18 @@ class Connection {
 
             for (const dbNameHash in state.databases) {
               state.databases[dbNameHash].init = false
+              dbsToReopen.push(dbNameHash)
             }
 
             this.init()
             this.reconnecting = true
 
-            // setting this.state = state here and after connect() maintains underlying memory references
-            this.state = state
-            const result = await this.connect(appId, sessionId, username, seedString, rememberMe, backUpKey, reconnectDelay)
-            this.state = state
+            const result = await this.connect(appId, sessionId, username, seedString, rememberMe, backUpKey, reconnectDelay, state)
+
+            this.reconnected = true
+
+            // only reopen databases on the first call to reconnect()
+            if (!currentState) await this.reopenDatabases(dbsToReopen, 1000)
 
             resolve(result)
           } catch (e) {
@@ -196,41 +344,32 @@ class Connection {
         },
         retryDelay
       )))
-
-      await this.reopenDatabases(1000)
     } catch (e) {
       rejectConnection(e)
     }
   }
 
-  async reopenDatabases(retryDelay) {
+  async reopenDatabases(dbsToReopen, retryDelay) {
     try {
       const openDatabasePromises = []
 
-      for (const dbNameHash in this.state.databases) {
-        if (!this.state.databases[dbNameHash].reopening) {
-          this.state.databases[dbNameHash].reopening = true
+      for (const dbNameHash of dbsToReopen) {
+        const database = this.state.databases[dbNameHash]
+
+        if (!database.init) {
           const action = 'OpenDatabase'
-          const params = { dbNameHash }
+          const params = { dbNameHash, reopenAtSeqNo: database.lastSeqNo }
           openDatabasePromises.push(this.request(action, params))
         }
       }
 
       await Promise.all(openDatabasePromises)
-
-      for (const dbNameHash in this.state.databases) {
-        this.state.databases[dbNameHash].reopening = false
-      }
-
     } catch (e) {
-      for (const dbNameHash in this.state.databases) {
-        this.state.databases[dbNameHash].reopening = false
-      }
 
       // keep attempting to reopen on failure
       await new Promise(resolve => setTimeout(
         async () => {
-          await this.reopenDatabases(retryDelay + BACKOFF_RETRY_DELAY)
+          await this.reopenDatabases(dbsToReopen, retryDelay + BACKOFF_RETRY_DELAY)
           resolve()
         },
         Math.min(retryDelay, MAX_RETRY_DELAY)
@@ -244,140 +383,8 @@ class Connection {
     const LATENCY_BUFFER = 3000
 
     this.pingTimeout = setTimeout(() => {
-      if (this.ws) this.ws.close(NO_PONG_RECEIVED)
+      if (this.ws) this.ws.close(statusCodes['No Pong Received'])
     }, 30000 + LATENCY_BUFFER)
-  }
-
-  async handleMessage(message) {
-    const route = message.route
-    switch (route) {
-      case 'Ping': {
-        this.heartbeat()
-
-        const action = 'Pong'
-        this.ws.send(JSON.stringify({ action }))
-        break
-      }
-
-      case 'Connection': {
-        this.connected = true
-
-        const {
-          salts,
-          encryptedValidationMessage
-        } = message
-
-        this.keys.salts = salts
-        this.encryptedValidationMessage = new Uint8Array(encryptedValidationMessage.data)
-
-        if (this.seedString) {
-          await this.setKeys(this.seedString)
-        }
-
-        break
-      }
-
-      case 'ApplyTransactions': {
-        const dbId = message.dbId
-        const dbNameHash = message.dbNameHash || this.state.dbIdToHash[dbId]
-        const database = this.state.databases[dbNameHash]
-
-        if (!database) return
-
-        const openingDatabase = message.dbNameHash && message.dbKey
-        if (openingDatabase) {
-          const dbKeyString = await crypto.aesGcm.decryptString(this.keys.encryptionKey, message.dbKey)
-          database.dbKeyString = dbKeyString
-          database.dbKey = await crypto.aesGcm.getKeyFromKeyString(dbKeyString)
-        }
-
-        if (!database.dbKey) return
-
-        if (message.bundle) {
-          const bundleSeqNo = message.bundleSeqNo
-          const base64Bundle = message.bundle
-          const compressedString = await crypto.aesGcm.decryptString(database.dbKey, base64Bundle)
-          const plaintextString = LZString.decompress(compressedString)
-          const bundle = JSON.parse(plaintextString)
-
-          database.applyBundle(bundle, bundleSeqNo)
-        }
-
-        const newTransactions = message.transactionLog
-        await database.applyTransactions(newTransactions)
-
-        if (!database.init) {
-          this.state.dbIdToHash[dbId] = dbNameHash
-          database.dbId = dbId
-          database.init = true
-          database.receivedMessage()
-        }
-
-        if (message.buildBundle) {
-          this.buildBundle(database)
-        }
-
-        break
-      }
-
-      case 'ReceiveRequestForSeed': {
-        if (!this.keys.init) return
-
-        const requesterPublicKey = message.requesterPublicKey
-        this.sendSeed(requesterPublicKey)
-
-        break
-      }
-
-      case 'ReceiveSeed': {
-        const { encryptedSeed, senderPublicKey } = message
-        const { seedRequestPrivateKey } = this.seedRequest
-
-        await this.receiveSeed(
-          encryptedSeed,
-          senderPublicKey,
-          seedRequestPrivateKey
-        )
-
-        break
-      }
-
-      case 'SignOut':
-      case 'UpdateUser':
-      case 'DeleteUser':
-      case 'CreateDatabase':
-      case 'GetDatabase':
-      case 'OpenDatabase':
-      case 'Insert':
-      case 'Update':
-      case 'Delete':
-      case 'BatchTransaction':
-      case 'Bundle':
-      case 'ValidateKey':
-      case 'RequestSeed':
-      case 'GetRequestsForSeed':
-      case 'SendSeed': {
-        const requestId = message.requestId
-
-        if (!requestId) return console.warn('Missing request id')
-
-        const request = this.requests[requestId]
-        if (!request) return console.warn(`Request ${requestId} no longer exists!`)
-        else if (!request.promiseResolve || !request.promiseReject) return
-
-        const response = message.response
-
-        const successfulResponse = response && response.status === statusCodes['Success']
-
-        if (!successfulResponse) return request.promiseReject(response)
-        else return request.promiseResolve(response)
-      }
-
-      default: {
-        console.log('Received unknown message from backend:' + JSON.stringify(message))
-        break
-      }
-    }
   }
 
   close(code) {

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -18,6 +18,7 @@ const MAX_RETRY_DELAY = 1000 * 30
 const SERVICE_RESTART = 1012
 const NO_PONG_RECEIVED = 3000
 
+const clientId = uuidv4() // only 1 client ID per browser tab (assumes code does not reload)
 
 class RequestFailed extends Error {
   constructor(action, e, ...params) {
@@ -104,7 +105,7 @@ class Connection {
       const host = removeProtocolFromEndpoint(config.getEndpoint())
       const protocol = getProtocolFromEndpoint(config.getEndpoint())
       const url = ((protocol === 'https') ?
-        'wss://' : 'ws://') + `${host}/api?appId=${appId}&sessionId=${sessionId}`
+        'wss://' : 'ws://') + `${host}/api?appId=${appId}&sessionId=${sessionId}&clientId=${clientId}`
 
       const ws = new WebSocket(url)
 

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -502,8 +502,11 @@ class Connection {
       items: database.items,
       itemsIndex: database.itemsIndex.array
     }
+    const plaintextString = JSON.stringify(bundle)
+
     const dbId = database.dbId
     const lastSeqNo = database.lastSeqNo
+    const dbKey = database.dbKey
 
     const itemKeyPromises = []
     for (let i = 0; i < bundle.itemsIndex.length; i++) {
@@ -512,9 +515,8 @@ class Connection {
     }
     const itemKeys = await Promise.all(itemKeyPromises)
 
-    const plaintextString = JSON.stringify(bundle)
     const compressedString = LZString.compress(plaintextString)
-    const base64Bundle = await crypto.aesGcm.encryptString(database.dbKey, compressedString)
+    const base64Bundle = await crypto.aesGcm.encryptString(dbKey, compressedString)
 
     const action = 'Bundle'
     const params = { dbId, seqNo: lastSeqNo, bundle: base64Bundle, keys: itemKeys }

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -163,7 +163,7 @@ async function start(express, app, userbaseConfig = {}) {
                     connectionId,
                     params.dbNameHash,
                     params.newDatabaseParams,
-                )
+                    params.reopenAtSeqNo
                   )
                   break
                 }

--- a/src/userbase-server/statusCodes.js
+++ b/src/userbase-server/statusCodes.js
@@ -4,5 +4,8 @@ export default {
   'Unauthorized': 401,
   'Not Found': 404,
   'Conflict': 409,
-  'Internal Server Error': 500
+  'Internal Server Error': 500,
+
+  // Custom ws close event codes
+  'Client Already Connected': 3001
 }

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -20,11 +20,12 @@ class Connection {
     this.requesterPublicKey = undefined
   }
 
-  openDatabase(databaseId, bundleSeqNo) {
+  openDatabase(databaseId, bundleSeqNo, reopenAtSeqNo) {
     this.databases[databaseId] = {
-      bundleSeqNo: bundleSeqNo >= 0 ? bundleSeqNo : -1,
-      lastSeqNo: 0,
-      transactionLogSize: 0
+      bundleSeqNo: bundleSeqNo > 0 ? bundleSeqNo : -1,
+      lastSeqNo: reopenAtSeqNo || 0,
+      transactionLogSize: 0,
+      init: reopenAtSeqNo !== undefined // ensures server sends the dbNameHash & key on first ever push, not reopen
     }
   }
 
@@ -32,7 +33,7 @@ class Connection {
     this.keyValidated = true
   }
 
-  async push(databaseId, dbNameHash, dbKey) {
+  async push(databaseId, dbNameHash, dbKey, reopenAtSeqNo) {
     const database = this.databases[databaseId]
     if (!database) return
 
@@ -42,21 +43,23 @@ class Connection {
       dbId: databaseId
     }
 
-    const openingDatabase = dbNameHash && dbKey
+    const reopeningDatabase = reopenAtSeqNo !== undefined
+
+    const openingDatabase = dbNameHash && dbKey && !reopeningDatabase
     if (openingDatabase) {
       payload.dbNameHash = dbNameHash
       payload.dbKey = dbKey
     }
 
-    const bundleSeqNo = database.bundleSeqNo
-    if (bundleSeqNo >= 0 && database.lastSeqNo === 0) {
-      const bundle = await db.getBundle(databaseId, bundleSeqNo)
-      payload.bundeSeqNo = bundleSeqNo
-      payload.bundle = bundle
-      database.lastSeqNo = bundleSeqNo
-    }
-
     let lastSeqNo = database.lastSeqNo
+    const bundleSeqNo = database.bundleSeqNo
+
+    if (bundleSeqNo > 0 && database.lastSeqNo === 0) {
+      const bundle = await db.getBundle(databaseId, bundleSeqNo)
+      payload.bundleSeqNo = bundleSeqNo
+      payload.bundle = bundle
+      lastSeqNo = bundleSeqNo
+    }
 
     // get transactions from the last sequence number
     const params = {
@@ -72,8 +75,7 @@ class Connection {
       }
     }
 
-    const transactionLog = []
-    let size = 0
+    const ddbTransactionLog = []
     try {
       const ddbClient = connection.ddbClient()
       let gapInSeqNo = false
@@ -82,14 +84,23 @@ class Connection {
         let transactionLogResponse = await ddbClient.query(params).promise()
 
         for (let i = 0; i < transactionLogResponse.Items.length && !gapInSeqNo; i++) {
-          size += estimateSizeOfDdbItem(transactionLogResponse.Items[i])
 
           // if there's a gap in sequence numbers and past rollback buffer, rollback all transactions in gap
           gapInSeqNo = transactionLogResponse.Items[i]['sequence-no'] > lastSeqNo + 1
           const secondsSinceCreation = gapInSeqNo && new Date() - new Date(transactionLogResponse.Items[i]['creation-date'])
 
+          // waiting gives opportunity for item to insert into DDB
           if (gapInSeqNo && secondsSinceCreation > SECONDS_BEFORE_ROLLBACK_GAP_TRIGGERED) {
-            await this.rollback(lastSeqNo, transactionLogResponse.Items[i]['sequence-no'], databaseId, ddbClient)
+            const rolledBackTransactions = await this.rollback(lastSeqNo, transactionLogResponse.Items[i]['sequence-no'], databaseId, ddbClient)
+
+            for (let j = 0; j < rolledBackTransactions.length; j++) {
+
+              // add transaction to the result set if have not sent it to client yet
+              if (rolledBackTransactions[j]['sequence-no'] > database.lastSeqNo) {
+                ddbTransactionLog.push(rolledBackTransactions[j])
+              }
+
+            }
           } else if (gapInSeqNo) {
             // at this point must stop querying for more transactions
             continue
@@ -97,20 +108,11 @@ class Connection {
 
           lastSeqNo = transactionLogResponse.Items[i]['sequence-no']
 
-          // don't add rollback transactions to the result set
-          if (transactionLogResponse.Items[i]['command'] === 'Rollback') {
-            continue
+          // add transaction to the result set if have not sent it to client yet
+          if (transactionLogResponse.Items[i]['sequence-no'] > database.lastSeqNo) {
+            ddbTransactionLog.push(transactionLogResponse.Items[i])
           }
 
-          // add transaction to the result set
-          transactionLog.push({
-            seqNo: transactionLogResponse.Items[i]['sequence-no'],
-            command: transactionLogResponse.Items[i]['command'],
-            key: transactionLogResponse.Items[i]['key'],
-            record: transactionLogResponse.Items[i]['record'],
-            operations: transactionLogResponse.Items[i]['operations'],
-            dbId: transactionLogResponse.Items[i]['database-id']
-          })
         }
 
         // paginate over all results
@@ -118,30 +120,55 @@ class Connection {
       } while (params.ExclusiveStartKey && !gapInSeqNo)
 
     } catch (e) {
-      logger.warn(`Failed to push with ${e}`)
+      logger.warn(`Failed to push to ${databaseId} with ${e}`)
       throw new Error(e)
     }
 
-    if (!transactionLog || transactionLog.length == 0) {
-      openingDatabase && this.socket.send(JSON.stringify(payload))
+    if (openingDatabase && database.lastSeqNo !== 0) {
+      logger.warn(`When opening database ${databaseId}, must send client entire transaction log from tip`)
       return
     }
 
-    payload.transactionLog = transactionLog
+    if (reopeningDatabase && database.lastSeqNo !== reopenAtSeqNo) {
+      logger.warn(`When reopening database ${databaseId}, must send client entire transaction log from requested seq no`)
+      return
+    }
 
-    this.sendPayload(payload, database, size)
+    if (!openingDatabase && !database.init) {
+      logger.warn(`Must finish opening database ${databaseId} before sending transactions to client`)
+      return
+    }
+
+    if (!ddbTransactionLog || ddbTransactionLog.length == 0) {
+      if (openingDatabase || reopeningDatabase) {
+        this.socket.send(JSON.stringify(payload))
+
+        if (payload.bundle) {
+          database.lastSeqNo = payload.bundleSeqNo
+        }
+
+        database.init = true
+      }
+      return
+    }
+
+    this.sendPayload(payload, ddbTransactionLog, database)
   }
 
   async rollback(lastSeqNo, thisSeqNo, databaseId, ddbClient) {
+    const rolledBackTransactions = []
+
     for (let i = lastSeqNo + 1; i <= thisSeqNo - 1; i++) {
+      const rolledbBackItem = {
+        'database-id': databaseId,
+        'sequence-no': i,
+        'command': 'Rollback',
+        'creation-date': new Date().toISOString()
+      }
+
       const rollbackParams = {
         TableName: setup.transactionsTableName,
-        Item: {
-          'database-id': databaseId,
-          'sequence-no': i,
-          'command': 'Rollback',
-          'creation-date': new Date().toISOString()
-        },
+        Item: rolledbBackItem,
         ConditionExpression: 'attribute_not_exists(#databaseId)',
         ExpressionAttributeNames: {
           '#databaseId': 'database-id'
@@ -149,20 +176,57 @@ class Connection {
       }
 
       await ddbClient.put(rollbackParams).promise()
+
+      rolledBackTransactions.push(rolledbBackItem)
     }
+
+    return rolledBackTransactions
   }
 
-  sendPayload(payload, database, size) {
-    const { transactionLog } = payload
+  sendPayload(payload, ddbTransactionLog, database) {
+    let size = 0
+
+    // only send transactions that have not been sent to client yet
+    const indexOfFirstTransactionToSend = ddbTransactionLog.findIndex(transaction => {
+
+      // check database.lastSeqNo bc could have been overwitten while DDB was paginating
+      return transaction['sequence-no'] > database.lastSeqNo
+    })
+
+    if (indexOfFirstTransactionToSend === -1) return
+
+    const transactionLog = ddbTransactionLog
+      .slice(indexOfFirstTransactionToSend)
+      .map(transaction => {
+        size += estimateSizeOfDdbItem(transaction)
+
+        return {
+          seqNo: transaction['sequence-no'],
+          command: transaction['command'],
+          key: transaction['key'],
+          record: transaction['record'],
+          operations: transaction['operations'],
+          dbId: transaction['database-id']
+        }
+      })
+
+    if (transactionLog.length === 0) return
+
+    // only send the payload if tx log starts with the next seqNo client is supposed to receive
+    if (transactionLog[0]['seqNo'] !== database.lastSeqNo + 1
+      && transactionLog[0]['seqNo'] !== payload.bundleSeqNo + 1) return
 
     if (database.transactionLogSize + size >= TRANSACTION_SIZE_BUNDLE_TRIGGER) {
-      this.socket.send(JSON.stringify({ ...payload, buildBundle: true }))
+      this.socket.send(JSON.stringify({ ...payload, transactionLog, buildBundle: true }))
       database.transactionLogSize = 0
     } else {
-      this.socket.send(JSON.stringify(payload))
+      this.socket.send(JSON.stringify({ ...payload, transactionLog }))
       database.transactionLogSize += size
     }
+
+    // database.lastSeqNo should be strictly increasing
     database.lastSeqNo = transactionLog[transactionLog.length - 1]['seqNo']
+    database.init = true
   }
 
   openSeedRequest(requesterPublicKey) {
@@ -219,14 +283,18 @@ export default class Connections {
     return connection
   }
 
-  static openDatabase(userId, connectionId, databaseId, bundleSeqNo, dbNameHash, dbKey) {
+  static openDatabase(userId, connectionId, databaseId, bundleSeqNo, dbNameHash, dbKey, reopenAtSeqNo) {
     if (!Connections.sockets || !Connections.sockets[userId] || !Connections.sockets[userId][connectionId]) return
 
     const conn = Connections.sockets[userId][connectionId]
-    conn.openDatabase(databaseId, bundleSeqNo)
-    logger.info(`Database ${databaseId} opened on connection ${connectionId}`)
 
-    conn.push(databaseId, dbNameHash, dbKey)
+    if (!conn.databases[databaseId]) {
+      conn.openDatabase(databaseId, bundleSeqNo, reopenAtSeqNo)
+      logger.info(`Database ${databaseId} opened on connection ${connectionId}`)
+    }
+
+    conn.push(databaseId, dbNameHash, dbKey, reopenAtSeqNo)
+
     return true
   }
 
@@ -240,18 +308,10 @@ export default class Connections {
       if (database && transaction['sequence-no'] === database.lastSeqNo + 1) {
         const payload = {
           route: 'ApplyTransactions',
-          transactionLog: [{
-            seqNo: transaction['sequence-no'],
-            command: transaction['command'],
-            key: transaction['key'],
-            record: transaction['record'],
-            operations: transaction['operations'],
-            dbId: transaction['database-id']
-          }],
           dbId: transaction['database-id']
         }
 
-        conn.sendPayload(payload, database, estimateSizeOfDdbItem(transaction))
+        conn.sendPayload(payload, [transaction], database)
       } else {
         conn.push(transaction['database-id'])
       }


### PR DESCRIPTION
### Major changes of this PR

1. The server will always send transactions in sequence.
2. The client will always apply transactions in sequence.
3. The client will apply batches of transactions received from the server one at a time in the order received from the server.
4. A client cannot open multiple web socket connections.
5. `userbase.openDatabase` is now idempotent. For every successive call to open database, the change handler is replaced with the latest call.
6. `userbase.init` is now idempotent. Once set, the app id and endpoint cannot be changed to something different. The key not found handler is replaced with the latest call.

Unfortunately since each major change is directly dependent on others, I think this whole PR needs to be reviewed in 1 pass as a collective change. Almost every line is critical.

I tried to separate the changes into different commits, however, I’m still of the opinion it would be best to review the entire PR collectively, rather than by commit.

### The biggest takeaway

I think we can rest assured that given change 2, honest clients will never be able to corrupt their state. This is achieved in [this commit](https://github.com/encrypted-dev/userbase/commit/fdb86ef814b6cc05cc9cb5dec1c6384fc2b729cf) in particular.