### PR TITLE
Payment Plan working as defined in spec

### DIFF
--- a/src/userbase-js/src/auth.js
+++ b/src/userbase-js/src/auth.js
@@ -62,6 +62,8 @@ const _parseUserResponseError = (e, username) => {
 
     if (data === 'UsernameAlreadyExists') {
       throw new errors.UsernameAlreadyExists(username)
+    } else if (data === 'TrialExceededLimit') {
+      throw new errors.TrialExceededLimit
     }
 
     switch (data.error) {
@@ -306,6 +308,7 @@ const signUp = async (username, password, email, profile, showKeyHandler, rememb
   } catch (e) {
 
     switch (e.name) {
+      case 'TrialExceededLimit':
       case 'UsernameAlreadyExists':
       case 'UsernameCannotBeBlank':
       case 'UsernameMustBeString':

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -300,6 +300,16 @@ class UserMissingExpectedProperties extends Error {
   }
 }
 
+class TrialExceededLimit extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'TrialExceededLimit'
+    this.message = 'Trial exceeded limit of users.'
+    this.status = statusCodes['Payment Required']
+  }
+}
+
 export default {
   UsernameAlreadyExists,
   UsernameCannotBeBlank,
@@ -330,4 +340,5 @@ export default {
   ShowKeyHandlerMustBeFunction,
   UserMustBeObject,
   UserMissingExpectedProperties,
+  TrialExceededLimit,
 }

--- a/src/userbase-js/src/statusCodes.js
+++ b/src/userbase-js/src/statusCodes.js
@@ -3,6 +3,7 @@ export default {
 
   'Bad Request': 400,
   'Unauthorized': 401,
+  'Payment Required': 402,
   'Not Found': 404,
   'Conflict': 409,
 

--- a/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
@@ -57,7 +57,6 @@ export default class AdminForm extends Component {
     try {
       if (formType === 'Create Admin') {
         await adminLogic.createAdmin(email, password, fullName)
-        window.alert('You are using the free version of Userbase!')
       } else if (formType === 'Sign In') {
         const paymentStatus = await adminLogic.signIn(email, password)
         handleUpdatePaymentStatus(paymentStatus)

--- a/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { string } from 'prop-types'
+import { string, func } from 'prop-types'
 import adminLogic from './logic'
 
 export default class AdminForm extends Component {
@@ -48,7 +48,7 @@ export default class AdminForm extends Component {
   }
 
   async handleSubmit(event) {
-    const { formType } = this.props
+    const { formType, handleUpdatePaymentStatus } = this.props
     const { email, password, fullName } = this.state
     event.preventDefault()
 
@@ -59,7 +59,8 @@ export default class AdminForm extends Component {
         await adminLogic.createAdmin(email, password, fullName)
         window.alert('You are using the free version of Userbase!')
       } else if (formType === 'Sign In') {
-        await adminLogic.signIn(email, password)
+        const paymentStatus = await adminLogic.signIn(email, password)
+        handleUpdatePaymentStatus(paymentStatus)
       } else {
         return console.error('Unknown form type')
       }
@@ -193,5 +194,6 @@ export default class AdminForm extends Component {
 
 AdminForm.propTypes = {
   formType: string,
-  placeholderEmail: string
+  placeholderEmail: string,
+  handleUpdatePaymentStatus: func
 }

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -103,8 +103,9 @@ const signIn = async (email, password) => {
       },
       timeout: TEN_SECONDS_MS
     })
-    const fullName = signInResponse.data
+    const { fullName, paymentStatus } = signInResponse.data
     signInLocalSession(lowerCaseEmail, fullName)
+    return paymentStatus
   } catch (e) {
     errorHandler(e, false)
   }
@@ -191,11 +192,13 @@ const updateSaasPaymentMethod = async () => {
 
 const cancelSaasSubscription = async () => {
   try {
-    await axios({
+    const cancelResponse = await axios({
       method: 'POST',
       url: `/${VERSION}/admin/stripe/cancel-saas-subscription`,
       timeout: TEN_SECONDS_MS
     })
+    const paymentStatus = cancelResponse.data
+    return paymentStatus
   } catch (e) {
     errorHandler(e)
   }
@@ -203,11 +206,13 @@ const cancelSaasSubscription = async () => {
 
 const resumeSaasSubscription = async () => {
   try {
-    await axios({
+    const resumeResponse = await axios({
       method: 'POST',
       url: `/${VERSION}/admin/stripe/resume-saas-subscription`,
       timeout: TEN_SECONDS_MS
     })
+    const paymentStatus = resumeResponse.data
+    return paymentStatus
   } catch (e) {
     errorHandler(e)
   }

--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -92,24 +92,22 @@ export default class AppUsersTable extends Component {
 
           <div className='flex mb-6'>
             <span className='flex-0'>{appName}</span>
-            {
-              paymentStatus && <div className='flex-1 text-right'>
-                {
-                  paymentStatus === 'active'
-                    ?
-                    <input
-                      className='btn w-32'
-                      type='button'
-                      value='Delete App'
-                      onClick={this.handleDeleteApp}
-                    />
-                    :
-                    <span className='italic font-light ml-3 text-red-600'>
-                      {appName} app can only have 3 users
+            <div className='flex-1 text-right'>
+              {
+                paymentStatus === 'active'
+                  ?
+                  <input
+                    className='btn w-32'
+                    type='button'
+                    value='Delete App'
+                    onClick={this.handleDeleteApp}
+                  />
+                  :
+                  <span className='italic font-light ml-3 text-red-600'>
+                    {appName} app can only have 3 users
                   </span>
-                }
-              </div>
-            }
+              }
+            </div>
           </div>
 
           {loading

--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -82,7 +82,7 @@ export default class AppUsersTable extends Component {
   }
 
   render() {
-    const { appName } = this.props
+    const { appName, paymentStatus } = this.props
     const { loading, appUsers, error } = this.state
 
     return (
@@ -91,15 +91,25 @@ export default class AppUsersTable extends Component {
         <div className='container content'>
 
           <div className='flex mb-6'>
-            <div className='flex-0 italic'>{appName}</div>
-            <div className='flex-1 text-right'>
-              <input
-                className='btn w-32'
-                type='button'
-                value='Delete App'
-                onClick={this.handleDeleteApp}
-              />
-            </div>
+            <span className='flex-0'>{appName}</span>
+            {
+              paymentStatus && <div className='flex-1 text-right'>
+                {
+                  paymentStatus === 'active'
+                    ?
+                    <input
+                      className='btn w-32'
+                      type='button'
+                      value='Delete App'
+                      onClick={this.handleDeleteApp}
+                    />
+                    :
+                    <span className='italic font-light ml-3 text-red-600'>
+                      {appName} app can only have 3 users
+                  </span>
+                }
+              </div>
+            }
           </div>
 
           {loading
@@ -169,5 +179,6 @@ export default class AppUsersTable extends Component {
 }
 
 AppUsersTable.propTypes = {
-  appName: string
+  appName: string,
+  paymentStatus: string
 }

--- a/src/userbase-server/admin-panel/components/Dashboard/Dashboard.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/Dashboard.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { string } from 'prop-types'
 import dashboardLogic from './logic'
 import adminLogic from '../Admin/logic'
 
@@ -72,6 +73,7 @@ export default class Dashboard extends Component {
   }
 
   render() {
+    const { paymentStatus } = this.props
     const { loading, apps, error, appName, loadingApp } = this.state
 
     return (
@@ -117,33 +119,37 @@ export default class Dashboard extends Component {
                 </table>
               }
 
-              <form className={`flex text-left ${(apps && apps.length) ? 'mt-8' : ''}`}>
-                <div className='flex-1'>
-                  <input
-                    className='input-text text-xs xs:text-sm w-36 xs:w-48'
-                    type='text'
-                    name='appName'
-                    autoComplete='off'
-                    value={appName}
-                    placeholder='New app'
-                    onChange={this.handleInputChange}
-                  />
-                </div>
+              {paymentStatus === 'active' &&
 
-                <div className='flex-1 text-center'>
-                  <input
-                    className='btn'
-                    type='submit'
-                    value='Add'
-                    disabled={!appName || loadingApp}
-                    onClick={this.handleCreateApp}
-                  />
-                </div>
+                <form className={`flex text-left ${(apps && apps.length) ? 'mt-8' : ''}`}>
+                  <div className='flex-1'>
+                    <input
+                      className='input-text text-xs xs:text-sm w-36 xs:w-48'
+                      type='text'
+                      name='appName'
+                      autoComplete='off'
+                      value={appName}
+                      placeholder='New app'
+                      onChange={this.handleInputChange}
+                    />
+                  </div>
 
-                <div className='flex-1 my-auto'>
-                  {loadingApp && <div className='loader w-6 h-6' />}
-                </div>
-              </form>
+                  <div className='flex-1 text-center'>
+                    <input
+                      className='btn'
+                      type='submit'
+                      value='Add'
+                      disabled={!appName || loadingApp}
+                      onClick={this.handleCreateApp}
+                    />
+                  </div>
+
+                  <div className='flex-1 my-auto'>
+                    {loadingApp && <div className='loader w-6 h-6' />}
+                  </div>
+                </form>
+              }
+
 
               {error && <div className='error text-left'>{error.message}</div>}
 
@@ -152,4 +158,8 @@ export default class Dashboard extends Component {
       </div>
     )
   }
+}
+
+Dashboard.propTypes = {
+  paymentStatus: string
 }

--- a/src/userbase-server/app.js
+++ b/src/userbase-server/app.js
@@ -14,7 +14,8 @@ async function createApp(appName, adminId, appId = uuidv4()) {
     'admin-id': adminId,
     'app-name': appName,
     'app-id': appId,
-    'creation-date': new Date().toISOString()
+    'creation-date': new Date().toISOString(),
+    'num-users': 0
   }
 
   const params = {
@@ -48,6 +49,12 @@ async function createApp(appName, adminId, appId = uuidv4()) {
 exports.createApp = createApp
 
 exports.createAppController = async function (req, res) {
+  const subscription = res.locals.subscription
+
+  if (!subscription || subscription.cancel_at_period_end || subscription.status !== 'active') return res
+    .status(statusCodes['Payment Required'])
+    .send('Pay subscription fee to create an app.')
+
   const appName = req.body.appName
 
   const admin = res.locals.admin
@@ -145,6 +152,12 @@ async function getAppByAppId(appId) {
 exports.getAppByAppId = getAppByAppId
 
 exports.deleteApp = async function (req, res) {
+  const subscription = res.locals.subscription
+
+  if (!subscription || subscription.cancel_at_period_end || subscription.status !== 'active') return res
+    .status(statusCodes['Payment Required'])
+    .send('Pay subscription fee to delete an app.')
+
   const appName = req.query.appName
 
   const admin = res.locals.admin
@@ -225,4 +238,42 @@ exports.listAppUsers = async function (req, res) {
       .status(statusCodes['Internal Server Error'])
       .send('Failed to list app users')
   }
+}
+
+const updateNumAppUsers = async function (adminId, appName, appId, increment) {
+  const incrementNumUsersParams = {
+    TableName: setup.appsTableName,
+    Key: {
+      'admin-id': adminId,
+      'app-name': appName
+    },
+    UpdateExpression: 'add #numUsers :num',
+    ConditionExpression: '#appId = :appId',
+    ExpressionAttributeNames: {
+      '#numUsers': 'num-users',
+      '#appId': 'app-id'
+    },
+    ExpressionAttributeValues: {
+      ':num': increment ? 1 : -1,
+      ':appId': appId
+    }
+  }
+
+  try {
+    const ddbClient = connection.ddbClient()
+    await ddbClient.update(incrementNumUsersParams).promise()
+  } catch (e) {
+    // failure ok -- this is a best effort attempt
+    logger.warn(`Failed to increment number of users for app ${appId} with ${e}`)
+  }
+}
+
+exports.incrementNumAppUsers = async function (adminId, appName, appId) {
+  const increment = true
+  await updateNumAppUsers(adminId, appName, appId, increment)
+}
+
+exports.decrementNumAppUsers = async function (adminId, appName, appId) {
+  const increment = false
+  await updateNumAppUsers(adminId, appName, appId, increment)
 }

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -154,7 +154,11 @@ async function start(express, app, userbaseConfig = {}) {
                   break
                 }
                 case 'DeleteUser': {
-                  response = await user.deleteUserController(userId)
+                  response = await user.deleteUserController(
+                    userId,
+                    res.locals.admin['admin-id'],
+                    res.locals.app['app-name']
+                  )
                   break
                 }
                 case 'OpenDatabase': {
@@ -267,24 +271,24 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/create-admin', admin.createAdminController)
     v1Admin.post('/sign-in', admin.signInAdmin)
     v1Admin.post('/sign-out', admin.authenticateAdmin, admin.signOutAdmin)
-    v1Admin.post('/create-app', admin.authenticateAdmin, appController.createAppController)
+    v1Admin.post('/create-app', admin.authenticateAdmin, admin.getSaasSubscriptionController, appController.createAppController)
     v1Admin.post('/list-apps', admin.authenticateAdmin, appController.listApps)
     v1Admin.post('/list-app-users', admin.authenticateAdmin, appController.listAppUsers)
-    v1Admin.post('/delete-app', admin.authenticateAdmin, appController.deleteApp)
+    v1Admin.post('/delete-app', admin.authenticateAdmin, admin.getSaasSubscriptionController, appController.deleteApp)
     v1Admin.post('/delete-user', admin.authenticateAdmin, admin.deleteUser)
-    v1Admin.post('/delete-admin', admin.authenticateAdmin, admin.getSaasSubscription, admin.deleteAdmin)
+    v1Admin.post('/delete-admin', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.deleteAdmin)
     v1Admin.post('/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1Admin.post('/forgot-password', admin.forgotPassword)
-    v1Admin.get('/payment-status', admin.authenticateAdmin, admin.getSaasSubscription, (req, res) => {
+    v1Admin.get('/payment-status', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
       const subscription = res.locals.subscription
       if (!subscription) return res.end()
       return res.send(subscription.cancel_at_period_end ? 'cancel_at_period_end' : subscription.status)
     })
 
     v1Admin.post('/stripe/create-saas-payment-session', admin.authenticateAdmin, admin.createSaasPaymentSession)
-    v1Admin.post('/stripe/update-saas-payment-session', admin.authenticateAdmin, admin.getSaasSubscription, admin.updateSaasSubscriptionPaymentSession)
-    v1Admin.post('/stripe/cancel-saas-subscription', admin.authenticateAdmin, admin.getSaasSubscription, admin.cancelSaasSubscription)
-    v1Admin.post('/stripe/resume-saas-subscription', admin.authenticateAdmin, admin.getSaasSubscription, admin.resumeSaasSubscription)
+    v1Admin.post('/stripe/update-saas-payment-session', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.updateSaasSubscriptionPaymentSession)
+    v1Admin.post('/stripe/cancel-saas-subscription', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.cancelSaasSubscription)
+    v1Admin.post('/stripe/resume-saas-subscription', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.resumeSaasSubscription)
 
   } catch (e) {
     logger.info(`Unhandled error while launching server: ${e}`)

--- a/src/userbase-server/statusCodes.js
+++ b/src/userbase-server/statusCodes.js
@@ -2,6 +2,7 @@ export default {
   'Success': 200,
   'Bad Request': 400,
   'Unauthorized': 401,
+  'Payment Required': 402,
   'Not Found': 404,
   'Conflict': 409,
   'Internal Server Error': 500,


### PR DESCRIPTION
### Creating an Admin

![CreateTrialApp](https://user-images.githubusercontent.com/26468430/72563934-902ce300-3863-11ea-9b24-bf50a46117b1.gif)

### Payment Flow

![PaymentFlow](https://user-images.githubusercontent.com/26468430/72564280-4264aa80-3864-11ea-941d-39eb275ec0e1.gif)

### Summary

Copied from @dvassallo 's message on Basecamp with some things left out:

1. When you sign up for an admin account, the system will automatically create a "Trial" app for you.

2. When you click on the Trial app, you get a message at the top that says that the trial app can only have 3 users.

3. We won't allow the creation of new apps unless you have a subscription. We verify this server-side and return an error if you try to create a new App and you don't have a subscription.

4. On signUp, we check if the app is a Trial type, and we return an error if there are already 3 users AND the account doesn't have a subscription.

5. Once the account gets a subscription, the Trial app becomes a regular app. The admin can rename it and keep using it just like any app.

### Caveats

- Someone using the open source `userbase-server` will need a Stripe account to create an app, delete an app, or sign up >3 users to an app
- It's possible a trial could have >3 users if users make >3 concurrent sign up requests at one time (this is only possible in the window of time _after_ a user signs up and _before_ the counter is incremented). This was done to enable high concurrency of sign ups for paying users, rather than guarantee a hard limit of 3 at the expense of concurrency
- There is no ability to rename an app
- On userbase.signUp, we just check if the admin has paid without checking the app type, and we return an error if there are already 3 users for that app