### PR TITLE
Finish stripe payments

### DIFF
--- a/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { string, func } from 'prop-types'
 import adminLogic from './logic'
+import UnknownError from './UnknownError'
 
 export default class AdminForm extends Component {
   constructor(props) {
@@ -163,7 +164,7 @@ export default class AdminForm extends Component {
 
           </div>
 
-          <div className='text-center mt-3 h-16'>
+          <div className={`text-center mt-3 ${!error ? 'h-16' : ''}`}>
             <div className='h-6'>
               {loading
                 ? <div className='loader inline-block w-6 h-6' />
@@ -176,7 +177,11 @@ export default class AdminForm extends Component {
               }
             </div>
 
-            <div className='error'>{error}</div>
+            {error && (error === 'Unknown Error'
+              ? <UnknownError />
+              : <div className='error'>{error}</div>
+            )}
+
           </div>
 
           {formType === 'Sign In' && <div>

--- a/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
@@ -10,14 +10,14 @@ export default class EditAdmin extends Component {
       email: '',
       fullName: '',
       password: '',
-      loadingUpdate: false,
-      loadingDelete: false,
+      loadingUpdateAdmin: false,
+      loadingDeleteAdmin: false,
       loadingCheckout: false,
       loadingCancel: false,
       loadingUpdatePaymentMethod: false,
       loadingResumeSubscription: false,
-      errorUpdating: '',
-      errorDeleting: '',
+      errorUpdatingAdmin: '',
+      errorDeletingAdmin: '',
       errorCheckingOut: false,
       errorCancelling: false,
       errorUpdatingPaymentMethod: false,
@@ -52,8 +52,8 @@ export default class EditAdmin extends Component {
   }
 
   handleInputChange(event) {
-    if (this.state.errorUpdating || this.state.errorDeleting) {
-      this.setState({ errorUpdating: undefined, errorDeleting: undefined })
+    if (this.state.errorUpdatingAdmin || this.state.errorDeletingAdmin) {
+      this.setState({ errorUpdatingAdmin: undefined, errorDeletingAdmin: undefined })
     }
 
     const target = event.target
@@ -71,29 +71,29 @@ export default class EditAdmin extends Component {
 
     if (!email && !password && !fullName) return
 
-    this.setState({ loadingUpdate: true })
+    this.setState({ loadingUpdateAdmin: true })
 
     try {
       await adminLogic.updateAdmin({ email, password, fullName })
       if (email || fullName) this.props.handleUpdateAccount(email, fullName)
-      if (this._isMounted) this.setState({ email: '', password: '', fullName: '', loadingUpdate: false })
+      if (this._isMounted) this.setState({ email: '', password: '', fullName: '', loadingUpdateAdmin: false })
     } catch (e) {
-      if (this._isMounted) this.setState({ errorUpdating: e.message, loadingUpdate: false })
+      if (this._isMounted) this.setState({ errorUpdatingAdmin: e.message, loadingUpdateAdmin: false })
     }
   }
 
   async handleDeleteAccount(event) {
     event.preventDefault()
 
-    this.setState({ errorDeleting: '' })
+    this.setState({ errorDeletingAdmin: '' })
 
     try {
       if (window.confirm('Are you sure you want to delete your account?')) {
-        this.setState({ loadingDelete: true })
+        this.setState({ loadingDeleteAdmin: true })
         await adminLogic.deleteAdmin()
       }
     } catch (e) {
-      if (this._isMounted) this.setState({ errorDeleting: e.message, loadingDelete: false })
+      if (this._isMounted) this.setState({ errorDeletingAdmin: e.message, loadingDeleteAdmin: false })
     }
   }
 
@@ -168,14 +168,14 @@ export default class EditAdmin extends Component {
       fullName,
       email,
       password,
-      loadingUpdate,
-      loadingDelete,
+      loadingUpdateAdmin,
+      loadingDeleteAdmin,
       loadingCheckout,
       loadingCancel,
       loadingUpdatePaymentMethod,
       loadingResumeSubscription,
-      errorUpdating,
-      errorDeleting,
+      errorUpdatingAdmin,
+      errorDeletingAdmin,
       errorCheckingOut,
       errorCancelling,
       errorUpdatingPaymentMethod,
@@ -301,11 +301,16 @@ export default class EditAdmin extends Component {
             <input
               className='btn w-40 mt-4'
               type='submit'
-              value={loadingUpdate ? 'Updating...' : 'Update Account'}
-              disabled={(!fullName && !email && !password) || loadingDelete || loadingUpdate}
+              value={loadingUpdateAdmin ? 'Updating...' : 'Update Account'}
+              disabled={(!fullName && !email && !password) || loadingDeleteAdmin || loadingUpdateAdmin}
             />
 
-            <div className='error'>{errorUpdating}</div>
+            {errorUpdatingAdmin && (
+              errorUpdatingAdmin === 'Unknown Error'
+                ? <UnknownError action='updating your account' />
+                : <div className='error'>{errorUpdatingAdmin}</div>
+            )}
+
           </div>
 
         </form>
@@ -315,12 +320,16 @@ export default class EditAdmin extends Component {
         <input
           className='btn w-40'
           type='button'
-          value={loadingDelete ? 'Deleting...' : 'Delete Account'}
-          disabled={loadingDelete}
+          value={loadingDeleteAdmin ? 'Deleting...' : 'Delete Account'}
+          disabled={loadingDeleteAdmin}
           onClick={this.handleDeleteAccount}
         />
 
-        {errorDeleting && <div className='error'>{errorDeleting}</div>}
+        {errorDeletingAdmin && (
+          errorDeletingAdmin === 'Unknown Error'
+            ? <UnknownError action='deleting your account' />
+            : <div className='error'>{errorDeletingAdmin}</div>
+        )}
 
       </div>
     )

--- a/src/userbase-server/admin-panel/components/Admin/UnknownError.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/UnknownError.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { string } from 'prop-types'
+
+export default function UnknownError({ action }) {
+  return (
+    <div className='error'>
+      {`Oops! Something went wrong${action ? (' ' + action) : ''}. Please hit refresh and try again!`}
+      <br />
+      <br />
+      If the issue persists, please contact <a href='mailto:support@userbase.com'>support@userbase.com</a>
+    </div>
+  )
+}
+
+UnknownError.propTypes = {
+  error: string,
+  action: string
+}

--- a/src/userbase-server/admin-panel/components/Admin/UnknownError.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/UnknownError.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { string } from 'prop-types'
+import { string, bool } from 'prop-types'
 
-export default function UnknownError({ action }) {
+export default function UnknownError({ action, noMarginTop }) {
   return (
-    <div className='error'>
+    <div className={`error ${noMarginTop ? 'mt-0' : ''}`}>
       {`Oops! Something went wrong${action ? (' ' + action) : ''}. Please hit refresh and try again!`}
       <br />
       <br />
@@ -13,6 +13,6 @@ export default function UnknownError({ action }) {
 }
 
 UnknownError.propTypes = {
-  error: string,
-  action: string
+  action: string,
+  noMarginTop: bool
 }

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -9,12 +9,13 @@ const errorHandler = (e, signOutUnauthorized = true) => {
   if (e && e.response) {
     if (signOutUnauthorized && e.response.status === UNAUTHORIZED) {
       handleSignOut()
+    } else if (e.response.status >= 500) {
+      throw new Error('Unknown Error')
     } else {
       throw new Error(e.response.data)
     }
-  } else {
-    throw e
   }
+  throw e
 }
 
 const handleSignOut = () => {

--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import { string } from 'prop-types'
 import dashboardLogic from './logic'
+import UnknownError from '../Admin/UnknownError'
 
 export default class AppUsersTable extends Component {
   constructor(props) {
@@ -24,7 +25,7 @@ export default class AppUsersTable extends Component {
       const appUsers = await dashboardLogic.listAppUsers(appName)
       if (this._isMounted) this.setState({ appUsers, loading: false })
     } catch (e) {
-      if (this._isMounted) this.setState({ error: e, loading: false })
+      if (this._isMounted) this.setState({ error: e.message, loading: false })
     }
   }
 
@@ -43,7 +44,7 @@ export default class AppUsersTable extends Component {
         window.location.hash = '' // eslint-disable-line require-atomic-updates
       }
     } catch (e) {
-      if (this._isMounted) this.setState({ loading: false, error: e })
+      if (this._isMounted) this.setState({ loading: false, error: e.message })
     }
   }
 
@@ -76,7 +77,7 @@ export default class AppUsersTable extends Component {
       if (this._isMounted) {
         const { appUsers } = this.state
         appUsers[getUserIndex()].deleting = undefined
-        this.setState({ error: e, appUsers })
+        this.setState({ error: e.message, appUsers })
       }
     }
   }
@@ -167,7 +168,11 @@ export default class AppUsersTable extends Component {
               : !error && <p className='italic font-light'>No users yet.</p>
           }
 
-          {error && <div className='error'>{error.message}</div>}
+          {error && (
+            error === 'Unknown Error'
+              ? <UnknownError />
+              : <div className='error'>{error}</div>
+          )}
 
         </div>
 

--- a/src/userbase-server/admin-panel/components/Dashboard/Dashboard.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/Dashboard.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { string } from 'prop-types'
 import dashboardLogic from './logic'
 import adminLogic from '../Admin/logic'
+import UnknownError from '../Admin/UnknownError'
 
 export default class Dashboard extends Component {
   constructor(props) {
@@ -26,7 +27,7 @@ export default class Dashboard extends Component {
       const apps = await dashboardLogic.listApps()
       if (this._isMounted) this.setState({ apps, loading: false })
     } catch (e) {
-      if (this._isMounted) this.setState({ error: e, loading: false })
+      if (this._isMounted) this.setState({ error: e.message, loading: false })
     }
   }
 
@@ -56,7 +57,7 @@ export default class Dashboard extends Component {
 
       if (this._isMounted) this.setState({ apps: apps.concat(app), appName: '', error: '', loadingApp: false })
     } catch (err) {
-      if (this._isMounted) this.setState({ error: err, loadingApp: false })
+      if (this._isMounted) this.setState({ error: err.message, loadingApp: false })
     }
   }
 
@@ -150,8 +151,14 @@ export default class Dashboard extends Component {
                 </form>
               }
 
-
-              {error && <div className='error text-left'>{error.message}</div>}
+              {error &&
+                <div className='text-left'>
+                  {error === 'Unknown Error'
+                    ? <UnknownError />
+                    : <div className='error'>{error}</div>
+                  }
+                </div>
+              }
 
             </div>
         }

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -672,6 +672,10 @@ exports.updateSaasSubscriptionPaymentSession = async function (req, res) {
   const stripeCustomerId = admin['stripe-customer-id']
 
   try {
+    if (!stripeCustomerId) {
+      return res.status(statusCodes['Payment Required']).send('Must purchase subscription first')
+    }
+
     const session = await stripe.getClient().checkout.sessions.create({
       payment_method_types: ['card'],
       mode: 'setup',

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -249,7 +249,7 @@ exports.signInAdmin = async function (req, res) {
       .status(statusCodes['Success'])
       .send({
         fullName: admin['full-name'],
-        paymentStatus: subscription && subscription.status
+        paymentStatus: subscription && (subscription.cancel_at_period_end ? 'cancel_at_period_end' : subscription.status)
       })
   } catch (e) {
     logger.error(`Admin '${email}' failed to sign in with ${e}`)


### PR DESCRIPTION
- If an admin's payment status fails to load on sign in, prevents them from seeing the free version of the app. They instead see the error message in the screenshot below
- Improves loading logic and implements error handling for the endpoints that interact with the Stripe API
- All errors with status >= 500 now display a message similar to the one in the screenshot (sometimes they have slightly more detail e.g. Oops! Something went wrong updating your account. blah blah blah)

<img width="675" alt="Screen Shot 2020-01-22 at 12 42 22 AM" src="https://user-images.githubusercontent.com/26468430/72878721-55d2a400-3cb0-11ea-82bf-edd3701df13b.png">
