### PR TITLE
Admin access token + Internal profile

### DIFF
--- a/cypress/integration/signup.spec.js
+++ b/cypress/integration/signup.spec.js
@@ -526,7 +526,7 @@ describe('Signup Testing', function () {
         })
         .catch(error => {
           expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileCannotBeEmpty')
+          expect(error.name).to.be.equal('ProfileValueMustBeString')
         })
     })
   })

--- a/cypress/integration/signup.spec.js
+++ b/cypress/integration/signup.spec.js
@@ -459,6 +459,30 @@ describe('Signup Testing', function () {
     })
   })
 
+  it('Signup with a profile with a value with 0 length', function () {
+    let randomInfo
+
+    cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
+      randomInfo = { ...loginInfo, profile: { 'key': '' } }
+    })
+
+    cy.window().then((window) => {
+      const { userbase } = window
+      window._userbaseEndpoint = info.endpoint
+      userbase.init({ appId: info.appId })
+
+
+      return userbase.signUp(randomInfo)
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('ProfileValueCannotBeBlank')
+        })
+    })
+  })
+
   it('Signup with a profile with a null value', function () {
     let randomInfo
 
@@ -472,12 +496,14 @@ describe('Signup Testing', function () {
       userbase.init({ appId: info.appId })
 
 
-      return userbase.signUp(randomInfo).then((user) => {
-        expect(user.username, 'user.username').to.exists
-        expect(user.username, 'user.username to be the one signed up').to.equal(randomInfo.username)
-
-        return userbase.deleteUser()
-      })
+      return userbase.signUp(randomInfo)
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('ProfileValueMustBeString')
+        })
     })
   })
 
@@ -485,7 +511,7 @@ describe('Signup Testing', function () {
     let randomInfo
 
     cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
-      randomInfo = { ...loginInfo, profile: { 'key': null } }
+      randomInfo = { ...loginInfo, profile: { 'key': undefined } }
     })
 
     cy.window().then((window) => {
@@ -494,12 +520,38 @@ describe('Signup Testing', function () {
       userbase.init({ appId: info.appId })
 
 
-      return userbase.signUp(randomInfo).then((user) => {
-        expect(user.username, 'user.username').to.exists
-        expect(user.username, 'user.username to be the one signed up').to.equal(randomInfo.username)
+      return userbase.signUp(randomInfo)
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('ProfileCannotBeEmpty')
+        })
+    })
+  })
 
-        return userbase.deleteUser()
-      })
+  it('Signup with a profile with a false value', function () {
+    let randomInfo
+
+    cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
+      randomInfo = { ...loginInfo, profile: { 'key': false } }
+    })
+
+    cy.window().then((window) => {
+      const { userbase } = window
+      window._userbaseEndpoint = info.endpoint
+      userbase.init({ appId: info.appId })
+
+
+      return userbase.signUp(randomInfo)
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('ProfileValueMustBeString')
+        })
     })
   })
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -4,6 +4,7 @@
     "cypress/**",
     "src/userbase-js/",
     "src/proof-of-concept/client/",
-    "test/**"
+    "test/**",
+    "src/userbase-server/admin-panel/"
   ]
 }

--- a/src/proof-of-concept/client/App.jsx
+++ b/src/proof-of-concept/client/App.jsx
@@ -4,7 +4,7 @@ import dbLogic from './components/Dashboard/logic'
 import Dashboard from './components/Dashboard/Dashboard'
 import UserForm from './components/User/UserForm'
 
-const APP_ID = 'a87131a7-1c8a-4fea-ab16-ff98dbaeb5f8'
+const APP_ID = 'poc-id'
 
 export default class App extends Component {
   constructor(props) {

--- a/src/proof-of-concept/client/App.jsx
+++ b/src/proof-of-concept/client/App.jsx
@@ -4,7 +4,7 @@ import dbLogic from './components/Dashboard/logic'
 import Dashboard from './components/Dashboard/Dashboard'
 import UserForm from './components/User/UserForm'
 
-const APP_ID = 'poc-id'
+const APP_ID = 'a87131a7-1c8a-4fea-ab16-ff98dbaeb5f8'
 
 export default class App extends Component {
   constructor(props) {

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -216,6 +216,17 @@ class ProfileValueMustBeString extends Error {
   }
 }
 
+class ProfileValueCannotBeBlank extends Error {
+  constructor(key, ...params) {
+    super(key, ...params)
+
+    this.name = 'ProfileValueCannotBeBlank'
+    this.message = 'Profile value cannot be blank.'
+    this.status = statusCodes['Bad Request']
+    this.key = key
+  }
+}
+
 class ProfileValueTooLong extends Error {
   constructor(maxLen, key, value, ...params) {
     super(maxLen, key, value, ...params)
@@ -300,6 +311,7 @@ export default {
   ProfileKeyMustBeString,
   ProfileKeyTooLong,
   ProfileValueMustBeString,
+  ProfileValueCannotBeBlank,
   ProfileValueTooLong,
   RememberMeValueNotValid,
   ParamsMissing,

--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -14,8 +14,10 @@ export type RememberMeOption = 'session' | 'local' | 'none'
 
 export interface UserResult {
   username: string
+  userId: string
   email?: string
   profile?: UserProfile
+  internalProfile?: UserProfile
 }
 
 export type DatabaseChangeHandler = (items: Item[]) => void

--- a/src/userbase-server/admin-panel/webpack.config.js
+++ b/src/userbase-server/admin-panel/webpack.config.js
@@ -97,6 +97,11 @@ module.exports = (env, argv) => {
           target: 'http://localhost:8080/',
           ws: true,
           secure: false
+        },
+        '/access-tokens': {
+          target: 'http://localhost:8080/',
+          ws: true,
+          secure: false
         }
       }
     }

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -965,7 +965,8 @@ const createAccessToken = async function (adminId) {
     TableName: setup.adminAccessTokensTableName,
     Item: {
       'admin-id': adminId,
-      'access-token': accessToken
+      'access-token': accessToken,
+      'creation-date': new Date().toISOString()
     },
     ConditionExpression: 'attribute_not_exists(#adminId)',
     ExpressionAttributeNames: {

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -300,7 +300,7 @@ exports.authenticateAdmin = async function (req, res, next) {
 
   if (!sessionId) return res
     .status(statusCodes['Unauthorized'])
-    .send('Missing session token')
+    .send('Please sign in.')
 
   const params = {
     TableName: setup.sessionsTableName,

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -6,12 +6,15 @@ import statusCodes from './statusCodes'
 import logger from './logger'
 import appController from './app'
 import userController from './user'
-import { validateEmail } from './utils'
+import { validateEmail, trimReq } from './utils'
 import stripe from './stripe'
 
 // source: https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Session_Management_Cheat_Sheet.md#session-id-length
 const ACCEPTABLE_RANDOM_BYTES_FOR_SAFE_SESSION_ID = 16
 const SESSION_COOKIE_NAME = 'adminSessionId'
+
+const BASE_64_STRING_LENGTH_FOR_32_BYTES = 44
+const UUID_STRING_LENGTH = 36
 
 const HOURS_IN_A_DAY = 24
 const SECONDS_IN_A_DAY = 60 * 60 * HOURS_IN_A_DAY
@@ -950,5 +953,128 @@ exports.resumeSaasSubscription = async function (req, res) {
   } catch (e) {
     logger.error(`Failed to resume subscription for admin '${adminId}' with ${e}`)
     return res.status(statusCodes['Internal Server Error']).send('Failed to resume subscription')
+  }
+}
+
+const createAccessToken = async function (adminId) {
+  const accessToken = crypto
+    .randomBytes(ACCEPTABLE_RANDOM_BYTES_FOR_SAFE_SESSION_ID * 2) // the more bytes the safer
+    .toString('base64')
+
+  const params = {
+    TableName: setup.adminAccessTokensTableName,
+    Item: {
+      'admin-id': adminId,
+      'access-token': accessToken
+    },
+    ConditionExpression: 'attribute_not_exists(#adminId)',
+    ExpressionAttributeNames: {
+      '#adminId': 'admin-id'
+    }
+  }
+
+  const ddbClient = connection.ddbClient()
+  await ddbClient.put(params).promise()
+
+  return accessToken
+}
+
+const getAccessTokens = async function (adminId) {
+  const params = {
+    TableName: setup.adminAccessTokensTableName,
+    KeyConditionExpression: '#adminId = :adminId',
+    ExpressionAttributeNames: {
+      '#adminId': 'admin-id'
+    },
+    ExpressionAttributeValues: {
+      ':adminId': adminId
+    }
+  }
+
+  const ddbClient = connection.ddbClient()
+  const adminResponse = await ddbClient.query(params).promise()
+
+  let accessTokens = adminResponse.Items.length === 0
+    ? [{ 'access-token': await createAccessToken(adminId) }]
+    : adminResponse.Items.map(item => ({ 'access-token': item['access-token'] }))
+
+  return accessTokens
+}
+
+exports.getAccessTokens = async function (req, res) {
+  const { admin } = res.locals
+  const adminId = admin['admin-id']
+
+  try {
+    logger.child({ adminId, req: trimReq(req) }).info('Getting access tokens')
+
+    const accessTokens = await getAccessTokens(adminId)
+
+    logger.child({ adminId, req: trimReq(req) }).info('Retrieved access tokens')
+    return res.send(accessTokens)
+  } catch (e) {
+    const msg = 'Failed to get access tokens'
+    logger.child({ adminId, err: e, req: trimReq(req) }).error(msg)
+    return res.status(statusCodes['Internal Server Error']).send(msg)
+  }
+}
+
+const getAccessToken = async function (adminId, accessToken) {
+  const params = {
+    TableName: setup.adminAccessTokensTableName,
+    Key: {
+      'admin-id': adminId,
+      'access-token': accessToken
+    }
+  }
+
+  const ddbClient = connection.ddbClient()
+  const accessTokenResponse = await ddbClient.get(params).promise()
+  return accessTokenResponse.Item
+}
+
+const _validateAppId = (appId) => {
+  if (!appId) throw { status: statusCodes['Bad Request'], error: { message: 'Missing App ID' } }
+  if (typeof appId !== 'string') throw { status: statusCodes['Bad Request'], error: { message: 'App ID must be a string' } }
+  if (appId.length !== UUID_STRING_LENGTH) throw { status: statusCodes['Bad Request'], error: { message: 'App ID invalid' } }
+}
+
+const _validateAccessToken = (accessToken) => {
+  if (!accessToken) throw { status: statusCodes['Bad Request'], error: { message: 'Missing access token' } }
+  if (typeof accessToken !== 'string') throw { status: statusCodes['Bad Request'], error: { message: 'Access token must be a string' } }
+  if (accessToken.length !== BASE_64_STRING_LENGTH_FOR_32_BYTES) throw { status: statusCodes['Bad Request'], error: { message: 'Access token invalid' } }
+}
+
+exports.authenticateAccessToken = async function (req, res, next) {
+  const { accessToken, appId } = req.body
+
+  try {
+    logger.child({ appId, req: trimReq(req) }).info('Authenticating access token')
+
+    _validateAccessToken(accessToken)
+    _validateAppId(appId)
+
+    // check that access token belongs to the admin of the provided app
+    const app = await appController.getAppByAppId(appId)
+    if (!app || app['deleted']) throw { status: statusCodes['Not Found'], error: { message: 'App not found' } }
+
+    const [accessTokenItem, admin] = await Promise.all([
+      getAccessToken(app['admin-id'], accessToken),
+      findAdminByAdminId(app['admin-id'])
+    ])
+
+    if (!accessTokenItem || !admin || admin['deleted'] || accessTokenItem['admin-id'] !== admin['admin-id']) {
+      throw { status: statusCodes['Unauthorized'], error: { message: 'Access token invalid' } }
+    }
+
+    logger.child({ appId, req: trimReq(req) }).info('Successfully authenticated access token')
+    next()
+  } catch (e) {
+    const msg = 'Failed to authenticate access tokens'
+    logger.child({ appId, err: e, req: trimReq(req) }).error(msg)
+
+    return (e.status && e.error)
+      ? res.status(e.status).send(e.error)
+      : res.status(statusCodes['Internal Server Error']).send(msg)
   }
 }

--- a/src/userbase-server/peers.js
+++ b/src/userbase-server/peers.js
@@ -23,7 +23,7 @@ export default class Peers {
 
         } catch (e) {
           logger
-            .child({ userId, databaseId: transaction['database-id'], ipAddress, error: e })
+            .child({ userId, databaseId: transaction['database-id'], ipAddress, err: e })
             .warn('Failed to notify db update')
         }
       }

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -311,7 +311,7 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1Admin.post('/change-password', admin.authenticateAdmin, admin.changePassword)
     v1Admin.post('/forgot-password', admin.forgotPassword)
-    v1Admin.post('/update-internal-profile', admin.authenticateAccessToken, user.updateInternalProfile)
+    v1Admin.put('/internal-profile', admin.authenticateAccessToken, user.updateInternalProfile)
     v1Admin.get('/payment-status', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
       const subscription = res.locals.subscription
       if (!subscription) return res.end()

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -310,6 +310,8 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1Admin.post('/change-password', admin.authenticateAdmin, admin.changePassword)
     v1Admin.post('/forgot-password', admin.forgotPassword)
+    v1Admin.get('/access-tokens', admin.authenticateAdmin, admin.getAccessTokens)
+    v1Admin.post('/update-internal-profile', admin.authenticateAccessToken, user.updateInternalProfile)
     v1Admin.get('/payment-status', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
       const subscription = res.locals.subscription
       if (!subscription) return res.end()

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -342,7 +342,7 @@ async function start(express, app, userbaseConfig = {}) {
         connections.push(transaction, userId)
       } catch (e) {
         const msg = 'Error pushing internal transaction to connected clients'
-        logger.child({ userId, databaseId: transaction['database-id'], seqNo: transaction['seq-no'], error: e }).error(msg)
+        logger.child({ userId, databaseId: transaction['database-id'], seqNo: transaction['seq-no'], err: e }).error(msg)
         return res.status(statusCodes['Internal Server Error']).send(msg)
       }
 

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -286,6 +286,7 @@ async function start(express, app, userbaseConfig = {}) {
 
     // Userbase admin API
     app.use(express.static(path.join(__dirname + adminPanelDir)))
+    app.get('/access-tokens', cookieParser(), admin.authenticateAdmin, admin.getAccessTokens)
     const v1Admin = express.Router()
     app.use('/v1/admin', v1Admin)
 
@@ -310,7 +311,6 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1Admin.post('/change-password', admin.authenticateAdmin, admin.changePassword)
     v1Admin.post('/forgot-password', admin.forgotPassword)
-    v1Admin.get('/access-tokens', admin.authenticateAdmin, admin.getAccessTokens)
     v1Admin.post('/update-internal-profile', admin.authenticateAccessToken, user.updateInternalProfile)
     v1Admin.get('/payment-status', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
       const subscription = res.locals.subscription

--- a/src/userbase-server/setup.js
+++ b/src/userbase-server/setup.js
@@ -546,7 +546,7 @@ async function getEc2Peers(ec2, stackName, thisInstanceId) {
 
     return ec2Peers
   } catch (e) {
-    logger.child({ error: e }).warn('Failed to discover ec2 peers')
+    logger.child({ err: e }).warn('Failed to discover ec2 peers')
     return null
   }
 }

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -55,3 +55,5 @@ export const estimateSizeOfDdbItem = (item) => {
 
   return bytes
 }
+
+export const trimReq = (req) => ({ id: req.id, url: req.url })


### PR DESCRIPTION
### Overview

We've received a feature request from multiple people asking to enable admins to programmatically update values associated with individual users. Here's [one example](https://twitter.com/Dayhaysoos/status/1222914997728223234). This feature will enable admins to programmatically set a payment flag on a user and tie any other data to a user that only the admin can create.

This is done via an `internalProfile` object that only the admin can write to and only the user can read from. This object is not encrypted.

### Implementation Overview

- Admins will need an "access token" to include in the request to update a user's internal profile. Admins acquire the access token via a new REST endpoint `GET /access-tokens`.  We don't link to this endpoint from the Admin panel for now. Early beta testers of this feature can visit the URL manually _after_ they sign in to the admin panel and can find their access token there.
- We expose a new REST endpoint `PUT /v1/admin/internal-profile/{accessToken, appId, userId, internalProfile}`. The admin can call this endpoint from a cloud function (or any other context), without having to sign in with a username and password.
- We changed the SDK so that init and signIn return the internalProfile, but only if it exists. Otherwise it won't be there.
- We also changed the SDK so that init, signIn, and signUp all return the userId, so the admin can acquire it and use it downstream in the POST request to update the user's internal profile.
- Admins can delete the user's internalProfile by setting it to a falsey value.

#### Lower level details in this PR

- internal profile has same validation as regular user profile
- fixed error caused by 0 length values in profile (added the error `ProfileValueCannotBeBlank`)
- fixed issue where profile could have non-string value
- implemented some more refined logging and server-side error handling
