### PR TITLE
Forgot Password

### DIFF
--- a/cypress/integration/db-correctness.spec.js
+++ b/cypress/integration/db-correctness.spec.js
@@ -1,12 +1,4 @@
-const getRandomString = () => Math.random().toString().substring(2)
-const getStringOfByteLength = (byteLength) => {
-  const BYTES_IN_STRING = 2
-  return 'a'.repeat(byteLength / BYTES_IN_STRING)
-}
-
-const wait = (ms) => new Promise(resolve => {
-  setTimeout(() => resolve(), ms)
-})
+import { getRandomString, getStringOfByteLength, wait } from '../support/utils'
 
 const beforeEachHook = function () {
   cy.visit('./cypress/integration/index.html').then(async function (win) {

--- a/cypress/integration/forogtPassword.spec.js
+++ b/cypress/integration/forogtPassword.spec.js
@@ -1,0 +1,259 @@
+import { getRandomString } from '../support/utils'
+
+const beforeHook = function (setAppId) {
+  cy.clearLocalStorage()
+  sessionStorage.clear()
+
+  cy.visit('./cypress/integration/index.html').then(function (win) {
+    expect(win).to.have.property('userbase')
+    const userbase = win.userbase
+    this.currentTest.userbase = userbase
+
+    const { endpoint } = Cypress.env()
+    win._userbaseEndpoint = endpoint
+
+    if (setAppId) setAppId(userbase, this)
+  })
+}
+
+describe('Forgot Password Tests', function () {
+
+  describe('Correct app initialization', function () {
+    beforeEach(function () {
+      beforeHook(function (userbase, that) {
+        const { appId } = Cypress.env()
+        userbase.init({ appId })
+        that.currentTest.appId = appId
+      })
+    })
+
+    it('Default behavior', async function () {
+      const username = getRandomString()
+
+      await this.test.userbase.signUp({
+        username,
+        password: getRandomString(),
+        email: `${getRandomString()}@random.com`
+      })
+
+      await this.test.userbase.forgotPassword({ username })
+    })
+
+    it('rememberMe=session', async function () {
+      const username = getRandomString()
+
+      await this.test.userbase.signUp({
+        username,
+        password: getRandomString(),
+        email: `${getRandomString()}@random.com`,
+        rememberMe: 'session'
+      })
+
+      await this.test.userbase.forgotPassword({ username })
+    })
+
+    it('rememberMe=local', async function () {
+      const username = getRandomString()
+
+      await this.test.userbase.signUp({
+        username,
+        password: getRandomString(),
+        email: `${getRandomString()}@random.com`,
+        rememberMe: 'local'
+      })
+
+      await this.test.userbase.forgotPassword({ username })
+    })
+
+    it('rememberMe=none', async function () {
+      const username = getRandomString()
+
+      await this.test.userbase.signUp({
+        username,
+        password: getRandomString(),
+        email: `${getRandomString()}@random.com`,
+        rememberMe: 'none'
+      })
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('KeyNotFound')
+      }
+    })
+
+    it('Unknown user', async function () {
+      const username = getRandomString()
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('KeyNotFound')
+      }
+    })
+
+    it('Deleted user', async function () {
+      const username = getRandomString()
+
+      await this.test.userbase.signUp({
+        username,
+        password: getRandomString(),
+        email: `${getRandomString()}@random.com`
+      })
+
+      await this.test.userbase.deleteUser()
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('UserNotFound')
+      }
+    })
+
+    it('No email provided', async function () {
+      const username = getRandomString()
+
+      await this.test.userbase.signUp({
+        username,
+        password: getRandomString()
+      })
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('UserEmailNotFound')
+      }
+    })
+
+    it('Missing params object', async function () {
+      try {
+        await this.test.userbase.forgotPassword()
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('ParamsMustBeObject')
+      }
+    })
+
+    it('Incorrect params type', async function () {
+      try {
+        await this.test.userbase.forgotPassword(false)
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('ParamsMustBeObject')
+      }
+    })
+
+    it('Missing username', async function () {
+      try {
+        await this.test.userbase.forgotPassword({})
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('UsernameMissing')
+      }
+    })
+
+    it('Blank username', async function () {
+      try {
+        await this.test.userbase.forgotPassword({ username: '' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('UsernameCannotBeBlank')
+      }
+    })
+
+    it('Incorrect username type', async function () {
+      try {
+        await this.test.userbase.forgotPassword({ username: {} })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('UsernameMustBeString')
+      }
+    })
+
+    it('Non-existent user with fake key in local storage', async function () {
+      const username = getRandomString()
+
+      localStorage.setItem(`userbaseSeed.${this.test.appId}.${username}`, 'fakekey')
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('UserNotFound')
+      }
+    })
+
+    it('Incorrect key', async function () {
+      const username = getRandomString()
+
+      await this.test.userbase.signUp({
+        username,
+        password: getRandomString(),
+        email: `${getRandomString()}@random.com`
+      })
+
+      sessionStorage.setItem(`userbaseSeed.${this.test.appId}.${username}`, 'ZkeHqIBL5TdW/YpCC323EzdoSLEnudRu20xpyx6GUzY=')
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('KeyNotFound')
+      }
+    })
+
+    it('Username too long', async function () {
+      const username = 'a'.repeat(101)
+
+      localStorage.setItem(`userbaseSeed.${this.test.appId}.${username}`, 'fakekey')
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('UsernameTooLong')
+      }
+    })
+  })
+
+  describe('App ID not set', function () {
+    beforeEach(function () { beforeHook() })
+
+    it('App ID not set', async function () {
+      const username = getRandomString()
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('AppIdNotSet')
+      }
+    })
+  })
+
+  describe('App ID not valid', function () {
+    beforeEach(function () {
+      beforeHook(function (userbase, that) {
+        const fakeAppId = 'fake-app-id'
+        userbase.init({ appId: fakeAppId })
+        that.currentTest.appId = fakeAppId
+      })
+    })
+
+    it('App ID not valid', async function () {
+      const username = getRandomString()
+
+      localStorage.setItem(`userbaseSeed.${this.test.appId}.${username}`, 'fakekey')
+
+      try {
+        await this.test.userbase.forgotPassword({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'correct error name').to.equal('AppIdNotValid')
+      }
+    })
+  })
+
+})

--- a/cypress/integration/signup.spec.js
+++ b/cypress/integration/signup.spec.js
@@ -89,6 +89,64 @@ describe('Signup Testing', function () {
     })
   })
 
+  it('Signup a new user, params missing', function () {
+    cy.window().then((window) => {
+      const { userbase } = window
+      window._userbaseEndpoint = info.endpoint
+      userbase.init({ appId: info.appId })
+
+      return userbase.signUp()
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('ParamsMustBeObject')
+        })
+    })
+  })
+
+  it('Signup a new user, params as string', function () {
+    cy.window().then((window) => {
+      const { userbase } = window
+      window._userbaseEndpoint = info.endpoint
+      userbase.init({ appId: info.appId })
+
+      return userbase.signUp('bad-params')
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('ParamsMustBeObject')
+        })
+    })
+  })
+
+  it('Signup a new user, username missing', function () {
+    let randomInfo
+    cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
+      randomInfo = { ...loginInfo }
+    })
+
+    cy.window().then((window) => {
+      const { userbase } = window
+      window._userbaseEndpoint = info.endpoint
+      userbase.init({ appId: info.appId })
+
+      delete randomInfo.username
+
+      return userbase.signUp(randomInfo)
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('UsernameMissing')
+        })
+    })
+  })
+
   it('Signup a new user, blank username', function () {
     let randomInfo
     cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
@@ -177,6 +235,52 @@ describe('Signup Testing', function () {
     })
   })
 
+  it('Signup a new user, username too long', function () {
+    let randomInfo
+    cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
+      randomInfo = { ...loginInfo, username: 'a'.repeat(101) }
+    })
+
+    cy.window().then((window) => {
+      const { userbase } = window
+      window._userbaseEndpoint = info.endpoint
+      userbase.init({ appId: info.appId })
+
+      return userbase.signUp(randomInfo)
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('UsernameTooLong')
+        })
+    })
+  })
+
+  it('Signup a new user, password missing', function () {
+    let randomInfo
+
+    cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
+      randomInfo = { ...loginInfo }
+    })
+
+    cy.window().then((window) => {
+      const { userbase } = window
+      window._userbaseEndpoint = info.endpoint
+      userbase.init({ appId: info.appId })
+
+      delete randomInfo.password
+
+      return userbase.signUp(randomInfo)
+        .then(() => {
+          expect(true, 'signUp should not be successful').to.be.false
+        })
+        .catch(error => {
+          expect(error).to.be.a('Error')
+          expect(error.name).to.be.equal('PasswordMissing')
+        })
+    })
+  })
 
   it('Signup a new user, null password', function () {
     let randomInfo

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -1,0 +1,10 @@
+export const getRandomString = () => Math.random().toString().substring(2)
+
+export const getStringOfByteLength = (byteLength) => {
+  const BYTES_IN_STRING = 2
+  return 'a'.repeat(byteLength / BYTES_IN_STRING)
+}
+
+export const wait = (ms) => new Promise(resolve => {
+  setTimeout(() => resolve(), ms)
+})

--- a/src/proof-of-concept/client/components/User/UserForm.jsx
+++ b/src/proof-of-concept/client/components/User/UserForm.jsx
@@ -18,6 +18,7 @@ export default class UserForm extends Component {
 
     this.handleInputChange = this.handleInputChange.bind(this)
     this.handleSubmitForm = this.handleSubmitForm.bind(this)
+    this.handleForgotPassword = this.handleForgotPassword.bind(this)
     this.handleToggleRememberMe = this.handleToggleRememberMe.bind(this)
   }
 
@@ -73,6 +74,20 @@ export default class UserForm extends Component {
       else handleSetSignInError(user.error)
     } else {
       handleSubmit(user)
+    }
+  }
+
+  async handleForgotPassword() {
+    const { username } = this.state
+
+    this.setState({ loading: true })
+
+    try {
+      await userLogic.forgotPassword(username)
+      window.alert('Check your email!')
+      this.setState({ loading: false })
+    } catch (e) {
+      this.setState({ error: e.message, loading: false })
     }
   }
 
@@ -156,6 +171,12 @@ export default class UserForm extends Component {
                       onClick={this.handleToggleRememberMe}
                     />
                   </div>
+
+                  {formType === 'Sign In'
+                    && <div className='pt-2 sm:inline-block sm:float-right sm:pt-0 sm:pl-2'>
+                      <a className='cursor-pointer font-light text-xs xs:text-sm' onClick={this.handleForgotPassword}>Forgot password</a>
+                    </div>
+                  }
                 </div>
               </div>
 

--- a/src/proof-of-concept/client/components/User/logic.js
+++ b/src/proof-of-concept/client/components/User/logic.js
@@ -26,6 +26,7 @@ const signOut = async () => {
 const signIn = async (username, password, rememberMe) => {
   try {
     const result = await userbase.signIn({ username, password, rememberMe: rememberMe ? 'session' : 'none' })
+    if (result.usedTempPassword) window.alert('Signed in with temp password!')
     return result
   } catch (e) {
     return _errorHandler(e, 'sign in')
@@ -41,9 +42,19 @@ const init = async (settings) => {
   }
 }
 
+const forgotPassword = async (username) => {
+  try {
+    await userbase.forgotPassword({ username })
+  } catch (e) {
+    _errorHandler(e, 'forgot password')
+    throw e
+  }
+}
+
 export default {
   signUp,
   signOut,
   signIn,
   init,
+  forgotPassword
 }

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -10,6 +10,16 @@ class UsernameAlreadyExists extends Error {
   }
 }
 
+class UsernameMissing extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'UsernameMissing'
+    this.message = 'Username missing.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 class UsernameCannotBeBlank extends Error {
   constructor(...params) {
     super(...params)
@@ -36,6 +46,16 @@ class UsernameMustBeString extends Error {
 
     this.name = 'UsernameMustBeString'
     this.message = 'Username must be a string.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
+class PasswordMissing extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'PasswordMissing'
+    this.message = 'Password missing.'
     this.status = statusCodes['Bad Request']
   }
 }
@@ -112,13 +132,12 @@ class UserAlreadySignedIn extends Error {
 }
 
 class AppIdNotValid extends Error {
-  constructor(status, username, ...params) {
+  constructor(...params) {
     super(...params)
 
     this.name = 'AppIdNotValid'
     this.message = 'App ID not valid.'
-    this.status = status
-    this.username = username
+    this.status = statusCodes['Unauthorized']
   }
 }
 
@@ -138,6 +157,16 @@ class UserNotFound extends Error {
 
     this.name = 'UserNotFound'
     this.message = 'User not found.'
+    this.status = statusCodes['Not Found']
+  }
+}
+
+class UserEmailNotFound extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'UserEmailNotFound'
+    this.message = 'User does not have an email saved.'
     this.status = statusCodes['Not Found']
   }
 }
@@ -289,11 +318,23 @@ class CurrentPasswordIncorrect extends Error {
   }
 }
 
+class KeyNotFound extends Error {
+  constructor(message, ...params) {
+    super(message, ...params)
+
+    this.name = 'KeyNotFound'
+    this.message = message
+    this.status = statusCodes['Not Found']
+  }
+}
+
 export default {
   UsernameAlreadyExists,
+  UsernameMissing,
   UsernameCannotBeBlank,
   UsernameTooLong,
   UsernameMustBeString,
+  PasswordMissing,
   PasswordCannotBeBlank,
   PasswordTooShort,
   PasswordTooLong,
@@ -304,6 +345,7 @@ export default {
   AppIdNotValid,
   UserNotSignedIn,
   UserNotFound,
+  UserEmailNotFound,
   EmailNotValid,
   ProfileMustBeObject,
   ProfileCannotBeEmpty,
@@ -317,5 +359,6 @@ export default {
   ParamsMissing,
   TrialExceededLimit,
   CurrentPasswordMissing,
-  CurrentPasswordIncorrect
+  CurrentPasswordIncorrect,
+  KeyNotFound,
 }

--- a/src/userbase-js/src/errors/config.js
+++ b/src/userbase-js/src/errors/config.js
@@ -20,6 +20,16 @@ class AppIdMustBeString extends Error {
     this.status = statusCodes['Bad Request']
   }
 }
+
+class AppIdMissing extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'AppIdMissing'
+    this.message = 'Application ID missing.'
+    this.status = statusCodes['Bad Request']
+  }
+}
 class AppIdCannotBeBlank extends Error {
   constructor(...params) {
     super(...params)
@@ -33,5 +43,6 @@ class AppIdCannotBeBlank extends Error {
 export default {
   AppIdAlreadySet,
   AppIdMustBeString,
+  AppIdMissing,
   AppIdCannotBeBlank,
 }

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -1,5 +1,15 @@
 import statusCodes from '../statusCodes'
 
+class DatabaseNameMissing extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'DatabaseNameMissing'
+    this.message = 'Database name missing.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 class DatabaseNameCannotBeBlank extends Error {
   constructor(...params) {
     super(...params)
@@ -36,6 +46,16 @@ class DatabaseAlreadyOpening extends Error {
 
     this.name = 'DatabaseAlreadyOpening'
     this.message = 'Already attempting to open database.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
+class ChangeHandlerMissing extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'ChangeHandlerMissing'
+    this.message = 'Change handler missing.'
     this.status = statusCodes['Bad Request']
   }
 }
@@ -100,6 +120,16 @@ class ItemIdTooLong extends Error {
   }
 }
 
+class ItemIdMissing extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'ItemIdMissing'
+    this.message = 'Item id missing.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 class ItemIdCannotBeBlank extends Error {
   constructor(...params) {
     super(...params)
@@ -140,6 +170,16 @@ class ItemUpdateConflict extends Error {
   }
 }
 
+class OperationsMissing extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'OperationsMissing'
+    this.message = 'Operations missing.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 class OperationsMustBeArray extends Error {
   constructor(...params) {
     super(...params)
@@ -150,12 +190,12 @@ class OperationsMustBeArray extends Error {
   }
 }
 
-class CommandUnrecognized extends Error {
+class CommandNotRecognized extends Error {
   constructor(command, ...params) {
     super(command, ...params)
 
-    this.name = 'CommandUnrecognized'
-    this.message = `Command '${command}' unrecognized.`
+    this.name = 'CommandNotRecognized'
+    this.message = `Command '${command}' not recognized.`
     this.status = statusCodes['Bad Request']
   }
 }
@@ -181,22 +221,26 @@ class OperationsExceedLimit extends Error {
 }
 
 export default {
+  DatabaseNameMissing,
   DatabaseNameCannotBeBlank,
   DatabaseNameMustBeString,
   DatabaseNameTooLong,
   DatabaseAlreadyOpening,
+  ChangeHandlerMissing,
   ChangeHandlerMustBeFunction,
   DatabaseNotOpen,
   ItemMissing,
   ItemTooLarge,
   ItemIdMustBeString,
   ItemIdTooLong,
+  ItemIdMissing,
   ItemIdCannotBeBlank,
   ItemAlreadyExists,
   ItemDoesNotExist,
   ItemUpdateConflict,
+  OperationsMissing,
   OperationsMustBeArray,
   OperationsConflict,
   OperationsExceedLimit,
-  CommandUnrecognized
+  CommandNotRecognized
 }

--- a/src/userbase-js/src/index.js
+++ b/src/userbase-js/src/index.js
@@ -9,6 +9,7 @@ export default {
   signOut: auth.signOut,
   updateUser: auth.updateUser,
   deleteUser: auth.deleteUser,
+  forgotPassword: auth.forgotPassword,
 
   openDatabase: db.openDatabase,
 

--- a/src/userbase-js/src/utils.js
+++ b/src/userbase-js/src/utils.js
@@ -10,7 +10,7 @@ export const readArrayBufferAsString = (arrayBuffer) => {
   })
 }
 
-export const removeProtocolFromEndpoint = (endpoint) => {
+const removeProtocolFromEndpoint = (endpoint) => {
   const http = 'http://'
   const https = 'https://'
 
@@ -23,8 +23,16 @@ export const removeProtocolFromEndpoint = (endpoint) => {
   }
 }
 
-export const getProtocolFromEndpoint = (endpoint) => {
+const getProtocolFromEndpoint = (endpoint) => {
   return endpoint.split(':')[0]
+}
+
+export const getWsUrl = (endpoint) => {
+  const host = removeProtocolFromEndpoint(endpoint)
+  const protocol = getProtocolFromEndpoint(endpoint)
+
+  return ((protocol === 'https') ?
+    'wss://' : 'ws://') + host
 }
 
 export const byteSizeOfString = (string) => {

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -3,7 +3,7 @@ import uuidv4 from 'uuid/v4'
 import LZString from 'lz-string'
 import localData from './localData'
 import crypto from './Crypto'
-import { removeProtocolFromEndpoint, getProtocolFromEndpoint } from './utils'
+import { getWsUrl } from './utils'
 import statusCodes from './statusCodes'
 import config from './config'
 import errors from './errors'
@@ -94,10 +94,7 @@ class Connection {
         10000
       )
 
-      const host = removeProtocolFromEndpoint(config.getEndpoint())
-      const protocol = getProtocolFromEndpoint(config.getEndpoint())
-      const url = ((protocol === 'https') ?
-        'wss://' : 'ws://') + `${host}/api?appId=${config.getAppId()}&sessionId=${session.sessionId}&clientId=${clientId}`
+      const url = `${getWsUrl(config.getEndpoint())}/api?appId=${config.getAppId()}&sessionId=${session.sessionId}&clientId=${clientId}`
 
       const ws = new WebSocket(url)
 

--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -59,6 +59,8 @@ export interface Userbase {
 
   deleteUser(): Promise<void>
 
+  forgotPassword(params: { username: string }): Promise<void>
+
   openDatabase(params: { databaseName: string, changeHandler: DatabaseChangeHandler }): Promise<void>
 
   insertItem(params: { databaseName: string, item: any, itemId?: string }): Promise<void>

--- a/src/userbase-js/types/test.ts
+++ b/src/userbase-js/types/test.ts
@@ -7,6 +7,7 @@ const {
   signOut,
   updateUser,
   deleteUser,
+  forgotPassword,
   openDatabase,
   insertItem,
   updateItem,
@@ -101,6 +102,12 @@ updateUser({ profile: 'invalid' })
 
 // $ExpectType Promise<void>
 deleteUser()
+
+// $ExpectType Promise<void>
+forgotPassword({ username: 'tuser' })
+
+// $ExpectError
+forgotPassword({})
 
 // $ExpectType Promise<void>
 openDatabase({ databaseName: 'tdb', changeHandler: (items) => { } })

--- a/src/userbase-server/crypto/hkdf.js
+++ b/src/userbase-server/crypto/hkdf.js
@@ -1,0 +1,173 @@
+'use strict'
+
+import { stringToArrayBuffer } from '../utils'
+
+/**
+ * @file
+ *
+ * Source: https://github.com/futoin/util-js-hkdf
+ *
+ * Copyright 2018 FutoIn Project (https://futoin.org)
+ * Copyright 2018 Andrey Galkin <andrey@futoin.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { createHash, createHmac } = require('crypto')
+
+const g_digestLenCache = {}
+
+/**
+ * Get expected hash length.
+ *
+ * @func
+ * @alias hkdf.hash_length
+ * @param {string} hash - Hash algorithm
+ * @returns {integer} hash digest byte length
+ *
+ * @note Values are hardcoded with fallback for unknown algorithms.
+ */
+const hash_length = (hash) => {
+  switch (hash) {
+    case 'sha256': return 32
+    case 'sha512': return 64
+    case 'sha224': return 28
+    case 'sha384': return 48
+    case 'sha3-256': return 32
+    case 'sha3-512': return 64
+    case 'sha3-224': return 28
+    case 'sha3-384': return 48
+    case 'blake2s256': return 32
+    case 'blake2b512': return 64
+    case 'sha1': return 20
+    case 'md5': return 16
+    default: {
+      let len = g_digestLenCache[hash]
+
+      if (len === undefined) {
+        len = createHash(hash).digest().length
+        g_digestLenCache[hash] = len
+      }
+
+      return len
+    }
+  }
+}
+
+/**
+ * HKDF extract action.
+ *
+ * @func
+ * @alias hkdf.extract
+ * @param {string} hash - Hash algorithm
+ * @param {integer} hash_len - Hash digest length
+ * @param {Buffer|string} ikm - Initial Keying Material
+ * @param {Buffer|string} salt - Optional salt (recommended)
+ * @returns {Buffer} A buffer with pseudorandom key
+ *
+ * @note Values are hardcoded with fallback for unknown algorithms.
+ */
+const hkdf_extract = (hash, hash_len, ikm, salt) => {
+  const b_ikm = Buffer.isBuffer(ikm) ? ikm : Buffer.from(ikm)
+  const b_salt = (salt && salt.length) ? Buffer.from(salt) : Buffer.alloc(hash_len, 0)
+
+  return createHmac(hash, b_salt).update(b_ikm).digest()
+}
+
+/**
+ * HKDF expand action.
+ *
+ * @func
+ * @alias hkdf.expand
+ * @param {string} hash - Hash algorithm
+ * @param {integer} hash_len - Hash digest length
+ * @param {Buffer|string} prk - A buffer with pseudorandom key
+ * @param {integer} length - length of output keying material in octets
+ * @param {Buffer|string} info - Optional context (safe to skip)
+ * @returns {Buffer} A buffer with output keying material
+ *
+ * @note Values are hardcoded with fallback for unknown algorithms.
+ */
+const hkdf_expand = (hash, hash_len, prk, length, info) => {
+  const b_info = Buffer.from(info || '')
+  const info_len = b_info.length
+
+  const steps = Math.ceil(length / hash_len)
+
+  if (steps > 0xFF) {
+    throw new Error(`OKM length ${length} is too long for ${hash} hash`)
+  }
+
+  // use single buffer with unnecessary create/copy/move operations
+  const t = Buffer.alloc(hash_len * steps + info_len + 1)
+
+  for (let c = 1, start = 0, end = 0; c <= steps; ++c) {
+    // add info
+    b_info.copy(t, end)
+    // add counter
+    t[end + info_len] = c
+
+    createHmac(hash, prk)
+      // use view: T(C) = T(C-1) | info | C
+      .update(t.slice(start, end + info_len + 1))
+      .digest()
+      // put back to the same buffer
+      .copy(t, end)
+
+    start = end // used for T(C-1) start
+    end += hash_len // used for T(C-1) end & overall end
+  }
+
+  return t.slice(0, length)
+}
+
+/**
+ * HMAC-based Extract-and-Expand Key Derivation Function (HKDF)
+ *
+ * @param {Buffer|string} ikm - Initial Keying Material
+ * @param {integer} length - Required byte length of output
+ * @param {Buffer|string} salt='' - Optional salt (recommended)
+ * @param {Buffer|string} info='' - Optional context (safe to skip)
+ * @param {string} hash='SHA-256' - HMAC hash function to use
+ * @returns {Buffer} Raw buffer with derived key of @p length bytes
+ */
+function hkdf(ikm, length, { salt = '', info = '', hash = 'SHA-256' } = {}) {
+  hash = hash.toLowerCase().replace('-', '')
+
+  // 0. Hash length
+  const hash_len = hash_length(hash)
+
+  // 1. extract
+  const prk = hkdf_extract(hash, hash_len, ikm, salt)
+
+  // 2. expand
+  return hkdf_expand(hash, hash_len, prk, length, info)
+}
+
+const PASSWORD_TOKEN_NAME = 'password-token'
+const PASSWORD_TOKEN_NUM_BITS = 256
+const PASSWORD_TOKEN_NUM_BYTES = PASSWORD_TOKEN_NUM_BITS / 8
+
+const getPasswordToken = async (passwordHash, salt) => {
+  const ikm = stringToArrayBuffer(passwordHash)
+  const info = stringToArrayBuffer(PASSWORD_TOKEN_NAME)
+  const length = PASSWORD_TOKEN_NUM_BYTES
+  const hash = 'SHA-256'
+
+  const passwordToken = hkdf(ikm, length, { salt, info, hash })
+  return passwordToken.toString('base64')
+}
+
+export default {
+  getPasswordToken
+}

--- a/src/userbase-server/crypto/index.js
+++ b/src/userbase-server/crypto/index.js
@@ -3,11 +3,15 @@ import diffieHellman from './diffieHellman'
 import randomBytes from './randomBytes'
 import sha256 from './sha256'
 import bcrypt from './bcrypt'
+import scrypt from './scrypt'
+import hkdf from './hkdf'
 
 export default {
   aesGcm,
   diffieHellman,
   randomBytes,
   sha256,
-  bcrypt
+  bcrypt,
+  scrypt,
+  hkdf,
 }

--- a/src/userbase-server/crypto/scrypt.js
+++ b/src/userbase-server/crypto/scrypt.js
@@ -1,0 +1,75 @@
+import crypto from 'crypto'
+import { stringToArrayBuffer } from '../utils'
+
+/**
+ *
+ * From the Scrypt paper:
+ *
+ * "100ms is a reasonable upper bound on the delay which should be
+ * cryptographically imposed on interactive logins"
+ *
+ * Pg. 13
+ * https://www.tarsnap.com/scrypt/scrypt.pdf
+ *
+ * With an optimized Scrypt algorithm running on a 3.1 GHz Intel Core i5,
+ * N = 32768 is the highest work factor that takes <100ms for the
+ * algorithm to run. Thus, it's the latest recommended work factor.
+ *
+ * Source: https://blog.filippo.io/the-scrypt-parameters/
+ *
+ * However, we are not running an optimized version of the algorithm on a
+ * single machine. Users are running a pure js version written for the browser.
+ * Safari, for example, takes >6 seconds to run when N = 32768 on a 2.5 GHz
+ * Intel Core i5. A higher end CPU can only shave around 1 second off that time.
+ * Further, it takes over 1s to run in Firefox, and over 500ms to run in Chrome.
+ * This is an unacceptably slow interactive login delay to impose on users.
+ *
+ * Thus, we are going with N = 16384 to ensure interactive logins
+ * are closer to the reasonable delay the function will impose on users,
+ * while still maintaining a high level of security.
+ *
+ **/
+const N = 16384 // 16mb
+const r = 8
+const p = 1
+
+const PARAMS = {
+  N,
+  r,
+  p,
+
+  // "Memory upper bound. It is an error when (approximately) 128 * N * r > maxmem."
+  // source: https://nodejs.org/api/crypto.html#crypto_crypto_scrypt_password_salt_keylen_options_callback
+  maxmem: 128 * N * r * 2
+}
+
+const HASH_LENGTH = 32
+
+/**
+ * NIST recommendation:
+ *
+ * "The length of the randomly-generated portion of the salt shall be at least 128 bits."
+ *
+ * Section 5.1
+ * https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-132.pdf
+ *
+ **/
+const SALT_LENGTH = 16
+const generateSalt = () => crypto.randomBytes(SALT_LENGTH)
+
+// matches userbase-js/Crypto/scrypt.js implementation
+const hash = async (password, salt) => {
+  const passwordArrayBuffer = new Uint8Array(stringToArrayBuffer(password))
+  const result = await new Promise((resolve, reject) => {
+    crypto.scrypt(passwordArrayBuffer, salt, HASH_LENGTH, PARAMS, (err, derivedKey) => {
+      if (err) throw reject(err)
+      resolve(derivedKey)
+    })
+  })
+  return result.toString('base64')
+}
+
+export default {
+  generateSalt,
+  hash,
+}

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -5,7 +5,7 @@ import statusCodes from './statusCodes'
 import responseBuilder from './responseBuilder'
 import crypto from './crypto'
 import logger from './logger'
-import { validateEmail, trimReq, wait } from './utils'
+import { validateEmail, trimReq } from './utils'
 import appController from './app'
 import adminController from './admin'
 
@@ -1187,20 +1187,6 @@ exports.forgotPassword = async function (req, forgotPasswordToken, userProvidedF
 
     if (e.status && e.error) {
       logger.child({ appId, userId, statusCode: e.status, err: e.error, req: trimReq(req) }).warn(message)
-
-      if (e.error.name === 'KeyNotValid') {
-
-        // will return success response to client even if key was not valid. This way someone using the wrong key
-        // won't know whether or not it's the wrong key. Prevent a timing attack by waiting
-        // the average time it takes to generate password token and send the email
-        const LO_TIME_TO_GENERATE_AND_SEND_EMAIL = 400
-        const HI_TIME_TO_GENERATE_AND_SEND_EMAIL = 1000
-        const timeToWait = LO_TIME_TO_GENERATE_AND_SEND_EMAIL + (Math.random() * (HI_TIME_TO_GENERATE_AND_SEND_EMAIL - LO_TIME_TO_GENERATE_AND_SEND_EMAIL))
-        await wait(timeToWait)
-
-        return responseBuilder.successResponse()
-      }
-
       return responseBuilder.errorResponse(e.status, e.error)
     } else {
       const statusCode = statusCodes['Internal Server Error']

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -57,3 +57,18 @@ export const estimateSizeOfDdbItem = (item) => {
 }
 
 export const trimReq = (req) => ({ id: req.id, url: req.url })
+
+// matches stringToArrayBuffer from userbase-js/Crypto/utils
+// https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
+export const stringToArrayBuffer = (str) => {
+  let buf = new ArrayBuffer(str.length * 2) // 2 bytes for each char
+  let bufView = new Uint16Array(buf)
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i)
+  }
+  return buf
+}
+
+export const wait = (ms) => new Promise((resolve) => {
+  setTimeout(() => resolve(), ms)
+})

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -68,7 +68,3 @@ export const stringToArrayBuffer = (str) => {
   }
   return buf
 }
-
-export const wait = (ms) => new Promise((resolve) => {
-  setTimeout(() => resolve(), ms)
-})


### PR DESCRIPTION
## Forgot Password

Our top feature request so far is to let users reset their password. Userbase didn’t initially allow this because the user’s encryption key is stored on the Userbase server encrypted with a key derived from the user’s password. When the user signed in, the original password was needed to first retrieve and then decrypt the encryption key.

However, Userbase also allows you to let users automatically sign in after they close their browser by setting the `rememberMe` option to `'local'` in the signUp and signIn APIs. In this case, the user’s encryption key gets saved in the browser’s local storage.

Now, with the addition of the forgotPassword API, so long as the user still has access to a device that was previously used to log in with `rememberMe` set to `'local'`, the user will be able to regain full access to their account using a temporary password sent to their email.

###  **Recovery will not be possible if the user forgets their password AND loses access to all previously used devices (!!!)**

## Implementation Details

1. When `forgotPassword({ username })` is called, the client establishes a WebSocket connection with the server to prove it has the user's encryption key (or more accurately, the user's seed).
2. The server generates a random message, encrypts it such that only the user controlling the seed can decrypt the message, then sends the encrypted message to the client.
3. The client decrypts the message and sends it back to the server.
4. If correct, the server then sends the user an email with the temporary password and `forgotPassword` returns successfully.
5. The user can then sign in using the temporary password and then change their password by calling `updateUser({ currentPassword: tempPassword, newPassword })`.

## Notes from this PR

- The temporary password expires after 24hrs.
- signIn now returns a boolean `usedTempPassword` if the user signed in with the temporary password.
- My tests for `forgotPassword` do not make sure that the temporary password sends successfully to a user's email and they do not make sure that the temporary password can be used to sign in. They simply test the API's failure modes or if it returns successfully. This is because it seemed receiving the email in a test would require setting up a test email server or likely involve some other time-intensive workaround. I tested that the temporary passwords sends successfully and can be used to sign in and change a user's password manually.
- I added *Missing errors (e.g. DatabaseNameMissing) to all userbase-js functions to maintain consistency.
- Related #59