### PR TITLE
Added ItemInvalid error to insertItem, updateItem, and putTransaction

### DIFF
--- a/cypress/integration/db.spec.js
+++ b/cypress/integration/db.spec.js
@@ -153,7 +153,7 @@ describe('DB Tests', function () {
     describe('Failure Tests', function () {
       beforeEach(function () { beforeEachHook() })
 
-      it('Database params as false boolean', async function () {
+      it('Database params as false', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
 
         try {
@@ -190,7 +190,7 @@ describe('DB Tests', function () {
         }
       })
 
-      it('Database name as a false boolean', async function () {
+      it('Database name as false', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
 
         try {
@@ -242,7 +242,7 @@ describe('DB Tests', function () {
         }
       })
 
-      it('Item id as false boolean', async function () {
+      it('Item id as false', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
 
         try {
@@ -290,6 +290,19 @@ describe('DB Tests', function () {
         } catch (e) {
           expect(e.name, 'error name').to.equal('ItemMissing')
           expect(e.message, 'error message').to.equal('Item missing.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Item undefined', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.insertItem({ databaseName, item: undefined })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemCannotBeUndefined')
+          expect(e.message, 'error message').to.equal('Item cannot be undefined.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -396,10 +409,7 @@ describe('DB Tests', function () {
     describe('Failure Tests', function () {
       beforeEach(function () { beforeEachHook() })
 
-      it('Database params as false boolean', async function () {
-        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
-
+      it('Database params as false', async function () {
         try {
           await this.test.userbase.updateItem(false)
           throw new Error('should have failed')
@@ -412,7 +422,7 @@ describe('DB Tests', function () {
 
       it('Database not open', async function () {
         try {
-          await this.test.userbase.updateItem({ databaseName, item: 'test-item' })
+          await this.test.userbase.updateItem({ databaseName, item: 'test-item', itemId: 'fake-id' })
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNotOpen')
@@ -422,11 +432,8 @@ describe('DB Tests', function () {
       })
 
       it('Database name missing', async function () {
-        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
-
         try {
-          await this.test.userbase.updateItem({ item: 'test-item' })
+          await this.test.userbase.updateItem({ item: 'test-item', itemId: 'fake-id' })
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameMissing')
@@ -435,12 +442,9 @@ describe('DB Tests', function () {
         }
       })
 
-      it('Database name as a false boolean', async function () {
-        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
-
+      it('Database name as false', async function () {
         try {
-          await this.test.userbase.updateItem({ databaseName: false, item: 'test-item' })
+          await this.test.userbase.updateItem({ databaseName: false, item: 'test-item', itemId: 'fake-id' })
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameMustBeString')
@@ -450,11 +454,8 @@ describe('DB Tests', function () {
       })
 
       it('Database name as null', async function () {
-        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
-
         try {
-          await this.test.userbase.updateItem({ databaseName: null, item: 'test-item' })
+          await this.test.userbase.updateItem({ databaseName: null, item: 'test-item', itemId: 'fake-id' })
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameMustBeString')
@@ -464,11 +465,8 @@ describe('DB Tests', function () {
       })
 
       it('Database name as 0 length string', async function () {
-        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
-
         try {
-          await this.test.userbase.updateItem({ databaseName: '', item: 'test-item' })
+          await this.test.userbase.updateItem({ databaseName: '', item: 'test-item', itemId: 'fake-id' })
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameCannotBeBlank')
@@ -478,11 +476,8 @@ describe('DB Tests', function () {
       })
 
       it('Database name too long', async function () {
-        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
-
         try {
-          await this.test.userbase.updateItem({ databaseName: 'a'.repeat(51), item: 'test-item' })
+          await this.test.userbase.updateItem({ databaseName: 'a'.repeat(51), item: 'test-item', itemId: 'fake-id' })
           throw new Error('should have failed')
         } catch (e) {
           expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
@@ -491,9 +486,8 @@ describe('DB Tests', function () {
         }
       })
 
-      it('Item id as false boolean', async function () {
+      it('Item id as false', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
 
         try {
           await this.test.userbase.updateItem({ databaseName, item: 'test-item', itemId: false })
@@ -507,7 +501,6 @@ describe('DB Tests', function () {
 
       it('Item id missing', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
 
         try {
           await this.test.userbase.updateItem({ databaseName, item: 'test-item' })
@@ -521,7 +514,6 @@ describe('DB Tests', function () {
 
       it('Item id as 0 length string', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
 
         try {
           await this.test.userbase.updateItem({ databaseName, item: 'test-item', itemId: '' })
@@ -535,7 +527,6 @@ describe('DB Tests', function () {
 
       it('Item id too long', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
 
         try {
           await this.test.userbase.updateItem({ databaseName, item: 'test-item', itemId: 'a'.repeat(101) })
@@ -549,7 +540,6 @@ describe('DB Tests', function () {
 
       it('Item missing', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
-        await this.test.userbase.insertItem({ databaseName, item: 'test-item' })
 
         try {
           await this.test.userbase.updateItem({ databaseName })
@@ -561,11 +551,26 @@ describe('DB Tests', function () {
         }
       })
 
+      it('Item undefined', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const itemId = 'test-id'
+        await this.test.userbase.insertItem({ databaseName, item: 'test-item', itemId })
+
+        try {
+          await this.test.userbase.updateItem({ databaseName, item: undefined, itemId })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemCannotBeUndefined')
+          expect(e.message, 'error message').to.equal('Item cannot be undefined.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
       it('Item too large', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
 
         const itemId = 'test-id'
-
         await this.test.userbase.insertItem({ databaseName, item: 'test-item', itemId })
 
         const MAX_BYTE_SIZE = 10 * 1024

--- a/cypress/integration/db.spec.js
+++ b/cypress/integration/db.spec.js
@@ -27,7 +27,7 @@ const beforeEachHook = function () {
   })
 }
 
-const successfulInsertSingleItem = async function (itemToInsert, userbase) {
+const successfulInsertSingleItem = async function (itemToInsert, userbase, insideTransaction = false) {
   let successful
   let changeHandlerCallCount = 0
 
@@ -49,13 +49,21 @@ const successfulInsertSingleItem = async function (itemToInsert, userbase) {
   }
 
   await userbase.openDatabase({ databaseName, changeHandler })
-  await userbase.insertItem({ databaseName, item: itemToInsert })
+
+  if (!insideTransaction) {
+    await userbase.insertItem({ databaseName, item: itemToInsert })
+  } else {
+    await userbase.putTransaction({
+      databaseName,
+      operations: [{ command: 'Insert', item: itemToInsert }]
+    })
+  }
 
   expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(2)
   expect(successful, 'successful state').to.be.true
 }
 
-const successfulUpdateSingleItem = async function (itemToUpdate, userbase) {
+const successfulUpdateSingleItem = async function (itemToUpdate, userbase, insideTransaction = false) {
   let successful
   let changeHandlerCallCount = 0
 
@@ -80,7 +88,15 @@ const successfulUpdateSingleItem = async function (itemToUpdate, userbase) {
 
   await userbase.openDatabase({ databaseName, changeHandler })
   await userbase.insertItem({ databaseName, item: 'hello world', itemId: testItemId })
-  await userbase.updateItem({ databaseName, item: itemToUpdate, itemId: testItemId })
+
+  if (!insideTransaction) {
+    await userbase.updateItem({ databaseName, item: itemToUpdate, itemId: testItemId })
+  } else {
+    await userbase.putTransaction({
+      databaseName,
+      operations: [{ command: 'Update', item: itemToUpdate, itemId: testItemId }]
+    })
+  }
 
   expect(changeHandlerCallCount, 'changeHandler called correct number of times').to.equal(3)
   expect(successful, 'successful state').to.be.true
@@ -153,7 +169,7 @@ describe('DB Tests', function () {
     describe('Failure Tests', function () {
       beforeEach(function () { beforeEachHook() })
 
-      it('Database params as false', async function () {
+      it('Params as false', async function () {
         await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
 
         try {
@@ -422,7 +438,7 @@ describe('DB Tests', function () {
     describe('Failure Tests', function () {
       beforeEach(function () { beforeEachHook() })
 
-      it('Database params as false', async function () {
+      it('Params as false', async function () {
         try {
           await this.test.userbase.updateItem(false)
           throw new Error('should have failed')
@@ -625,6 +641,538 @@ describe('DB Tests', function () {
           expect(e.name, 'error name').to.equal('ItemDoesNotExist')
           expect(e.message, 'error message').to.equal('Item with the provided id does not exist.')
           expect(e.status, 'error status').to.equal(404)
+        }
+      })
+
+    })
+
+  })
+
+  describe('Put Transaction', function () {
+
+    describe('Success Tests', function () {
+      const insideTransaction = true
+
+      beforeEach(function () { beforeEachHook() })
+
+      it('Insert null', async function () {
+        const itemToInsert = null
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert 0 length string', async function () {
+        const itemToInsert = ''
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert string', async function () {
+        const itemToInsert = 'Hello, world!'
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert 0', async function () {
+        const itemToInsert = 0
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert 1', async function () {
+        const itemToInsert = 1
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert false', async function () {
+        const itemToInsert = false
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert true', async function () {
+        const itemToInsert = true
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert empty array', async function () {
+        const itemToInsert = []
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert array with 1 element', async function () {
+        const itemToInsert = ['hello world']
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert empty object', async function () {
+        const itemToInsert = {}
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Insert object with 1 key set to null', async function () {
+        const itemToInsert = { testKey: null }
+        await successfulInsertSingleItem(itemToInsert, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to null', async function () {
+        const itemToUpdate = null
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to 0 length string', async function () {
+        const itemToUpdate = ''
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to string', async function () {
+        const itemToUpdate = 'Hello, world!'
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to 0', async function () {
+        const itemToUpdate = 0
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to 1', async function () {
+        const itemToUpdate = 1
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to false', async function () {
+        const itemToUpdate = false
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to true', async function () {
+        const itemToUpdate = true
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to empty array', async function () {
+        const itemToUpdate = []
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to array with 1 element', async function () {
+        const itemToUpdate = ['hello world']
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to empty object', async function () {
+        const itemToUpdate = {}
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+      it('Update to object with 1 key set to null', async function () {
+        const itemToUpdate = { testKey: null }
+        await successfulUpdateSingleItem(itemToUpdate, this.test.userbase, insideTransaction)
+      })
+
+    })
+
+    describe('Failure Tests', function () {
+      beforeEach(function () { beforeEachHook() })
+
+      it('Params as false', async function () {
+        try {
+          await this.test.userbase.putTransaction(false)
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ParamsMustBeObject')
+          expect(e.message, 'error message').to.equal('Parameters passed to function must be placed inside an object.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Database not open', async function () {
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert', item: 'test-item', itemId: 'fake-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('DatabaseNotOpen')
+          expect(e.message, 'error message').to.equal('Database is not open.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Database name missing', async function () {
+        try {
+          await this.test.userbase.putTransaction({ operations: [{ command: 'Insert', item: 'test-item', itemId: 'fake-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('DatabaseNameMissing')
+          expect(e.message, 'error message').to.equal('Database name missing.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Database name as false', async function () {
+        try {
+          await this.test.userbase.putTransaction({ databaseName: false, operations: [{ command: 'Insert', item: 'test-item', itemId: 'fake-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('DatabaseNameMustBeString')
+          expect(e.message, 'error message').to.equal('Database name must be a string.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Database name as null', async function () {
+        try {
+          await this.test.userbase.putTransaction({ databaseName: null, operations: [{ command: 'Insert', item: 'test-item', itemId: 'fake-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('DatabaseNameMustBeString')
+          expect(e.message, 'error message').to.equal('Database name must be a string.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Database name as 0 length string', async function () {
+        try {
+          await this.test.userbase.putTransaction({ databaseName: '', operations: [{ command: 'Insert', item: 'test-item', itemId: 'fake-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('DatabaseNameCannotBeBlank')
+          expect(e.message, 'error message').to.equal('Database name cannot be blank.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Database name too long', async function () {
+        try {
+          await this.test.userbase.putTransaction({ databaseName: 'a'.repeat(51), operations: [{ command: 'Insert', item: 'test-item', itemId: 'fake-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('DatabaseNameTooLong')
+          expect(e.message, 'error message').to.equal('Database name cannot be more than 50 characters.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Insert with item id as false', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert', item: 'test-item', itemId: false }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemIdMustBeString')
+          expect(e.message, 'error message').to.equal('Item id must be a string.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Insert with item id as 0 length string', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert', item: 'test-item', itemId: '' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemIdCannotBeBlank')
+          expect(e.message, 'error message').to.equal('Item id cannot be blank.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Insert with item id too long', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert', item: 'test-item', itemId: 'a'.repeat(101) }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemIdTooLong')
+          expect(e.message, 'error message').to.equal('Item id cannot be more than 100 characters.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Insert with item missing', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemMissing')
+          expect(e.message, 'error message').to.equal('Item missing.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Insert with item undefined', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert', item: undefined }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Insert with item as function', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert', item: () => { } }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Insert with item too large', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const MAX_BYTE_SIZE = 10 * 1024
+        const item = getStringOfByteLength(MAX_BYTE_SIZE)
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Insert', item }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemTooLarge')
+          expect(e.message, 'error message').to.equal('Item must be less than 10 KB.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item id as false', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: 'test-item', itemId: false }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemIdMustBeString')
+          expect(e.message, 'error message').to.equal('Item id must be a string.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item id missing', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: 'test-item' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemIdMissing')
+          expect(e.message, 'error message').to.equal('Item id missing.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item id as 0 length string', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: 'test-item', itemId: '' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemIdCannotBeBlank')
+          expect(e.message, 'error message').to.equal('Item id cannot be blank.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item id too long', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: 'test-item', itemId: 'a'.repeat(101) }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemIdTooLong')
+          expect(e.message, 'error message').to.equal('Item id cannot be more than 100 characters.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item missing', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemMissing')
+          expect(e.message, 'error message').to.equal('Item missing.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item undefined', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const itemId = 'test-id'
+        await this.test.userbase.insertItem({ databaseName, item: 'test-item', itemId })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: undefined, itemId }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item as function', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const itemId = 'test-id'
+        await this.test.userbase.insertItem({ databaseName, item: 'test-item', itemId })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: () => { }, itemId }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update with item too large', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const itemId = 'test-id'
+        await this.test.userbase.insertItem({ databaseName, item: 'test-item', itemId })
+
+        const MAX_BYTE_SIZE = 10 * 1024
+        const item = getStringOfByteLength(MAX_BYTE_SIZE)
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item, itemId }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemTooLarge')
+          expect(e.message, 'error message').to.equal('Item must be less than 10 KB.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Update item that does not exist', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command: 'Update', item: false, itemId: 'fake-item-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemDoesNotExist')
+          expect(e.message, 'error message').to.equal('Item with the provided id does not exist.')
+          expect(e.status, 'error status').to.equal(404)
+        }
+      })
+
+      it('Operations missing', async function () {
+        try {
+          await this.test.userbase.putTransaction({ databaseName })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('OperationsMissing')
+          expect(e.message, 'error message').to.equal('Operations missing.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Operations must be array', async function () {
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: false })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('OperationsMustBeArray')
+          expect(e.message, 'error message').to.equal('Operations provided must be an array.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Operations conflict', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const itemId = 'test-item-id'
+
+        try {
+          await this.test.userbase.putTransaction({
+            databaseName,
+            operations: [
+              { command: 'Insert', item: false, itemId },
+              { command: 'Insert', item: true, itemId },
+            ]
+          })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('OperationsConflict')
+          expect(e.message, 'error message').to.equal('Operations conflict. Only allowed 1 operation per item.')
+          expect(e.status, 'error status').to.equal(409)
+        }
+      })
+
+      it('Operations exceed limit', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const limit = 10
+
+        const operations = []
+        for (let i = 0; i <= limit; i++) {
+          operations.push({ command: 'Insert', item: i, itemId: i.toString() })
+        }
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('OperationsExceedLimit')
+          expect(e.message, 'error message').to.equal(`Operations exceed limit. Only allowed ${limit} operations.`)
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Command missing', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ item: false, itemId: 'fake-item-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('CommandNotRecognized')
+          expect(e.message, 'error message').to.equal(`Command '${undefined}' not recognized.`)
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Command as false', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const command = false
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command, item: false, itemId: 'fake-item-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('CommandNotRecognized')
+          expect(e.message, 'error message').to.equal(`Command '${command}' not recognized.`)
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Command incorrect', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const command = 'fake-command'
+
+        try {
+          await this.test.userbase.putTransaction({ databaseName, operations: [{ command, item: false, itemId: 'fake-item-id' }] })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('CommandNotRecognized')
+          expect(e.message, 'error message').to.equal(`Command '${command}' not recognized.`)
+          expect(e.status, 'error status').to.equal(400)
         }
       })
 

--- a/cypress/integration/db.spec.js
+++ b/cypress/integration/db.spec.js
@@ -301,8 +301,21 @@ describe('DB Tests', function () {
           await this.test.userbase.insertItem({ databaseName, item: undefined })
           throw new Error('should have failed')
         } catch (e) {
-          expect(e.name, 'error name').to.equal('ItemCannotBeUndefined')
-          expect(e.message, 'error message').to.equal('Item cannot be undefined.')
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Item as function', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        try {
+          await this.test.userbase.insertItem({ databaseName, item: () => { } })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
           expect(e.status, 'error status').to.equal(400)
         }
       })
@@ -561,8 +574,24 @@ describe('DB Tests', function () {
           await this.test.userbase.updateItem({ databaseName, item: undefined, itemId })
           throw new Error('should have failed')
         } catch (e) {
-          expect(e.name, 'error name').to.equal('ItemCannotBeUndefined')
-          expect(e.message, 'error message').to.equal('Item cannot be undefined.')
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
+          expect(e.status, 'error status').to.equal(400)
+        }
+      })
+
+      it('Item as a function', async function () {
+        await this.test.userbase.openDatabase({ databaseName, changeHandler: () => { } })
+
+        const itemId = 'test-id'
+        await this.test.userbase.insertItem({ databaseName, item: 'test-item', itemId })
+
+        try {
+          await this.test.userbase.updateItem({ databaseName, item: () => { }, itemId })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('ItemInvalid')
+          expect(e.message, 'error message').to.equal('Item must be serializable to JSON.')
           expect(e.status, 'error status').to.equal(400)
         }
       })

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -524,7 +524,7 @@ const insertItem = async (params) => {
       case 'ItemIdCannotBeBlank':
       case 'ItemIdTooLong':
       case 'ItemMissing':
-      case 'ItemCannotBeUndefined':
+      case 'ItemInvalid':
       case 'ItemTooLarge':
       case 'ItemAlreadyExists':
       case 'UserNotSignedIn':
@@ -545,8 +545,6 @@ const _buildInsertParams = async (database, params) => {
 
   const { item, itemId } = params
 
-  if (item === undefined) throw new errors.ItemCannotBeUndefined
-
   if (objectHasOwnProperty(params, 'itemId')) {
     if (typeof itemId !== 'string') throw new errors.ItemIdMustBeString
     if (itemId.length === 0) throw new errors.ItemIdCannotBeBlank
@@ -554,6 +552,7 @@ const _buildInsertParams = async (database, params) => {
   }
 
   const itemString = JSON.stringify(item)
+  if (!itemString) throw new errors.ItemInvalid
   if (byteSizeOfString(itemString) > MAX_ITEM_BYTES) throw new errors.ItemTooLarge(MAX_ITEM_KB)
 
   const id = itemId || uuidv4()
@@ -589,7 +588,7 @@ const updateItem = async (params) => {
       case 'ItemIdCannotBeBlank':
       case 'ItemIdTooLong':
       case 'ItemMissing':
-      case 'ItemCannotBeUndefined':
+      case 'ItemInvalid':
       case 'ItemTooLarge':
       case 'ItemDoesNotExist':
       case 'ItemUpdateConflict':
@@ -612,8 +611,6 @@ const _buildUpdateParams = async (database, params) => {
 
   const { item, itemId } = params
 
-  if (item === undefined) throw new errors.ItemCannotBeUndefined
-
   if (typeof itemId !== 'string') throw new errors.ItemIdMustBeString
   if (itemId.length === 0) throw new errors.ItemIdCannotBeBlank
   if (itemId.length > MAX_ITEM_ID_CHAR_LENGTH) throw new errors.ItemIdTooLong(MAX_ITEM_ID_CHAR_LENGTH)
@@ -621,6 +618,7 @@ const _buildUpdateParams = async (database, params) => {
   if (!database.itemExists(itemId)) throw new errors.ItemDoesNotExist
 
   const itemString = JSON.stringify(item)
+  if (!itemString) throw new errors.ItemInvalid
   if (byteSizeOfString(itemString) > MAX_ITEM_BYTES) throw new errors.ItemTooLarge(MAX_ITEM_KB)
 
   const itemKey = await crypto.hmac.signString(ws.keys.hmacKey, itemId)
@@ -757,6 +755,7 @@ const putTransaction = async (params) => {
       case 'ItemIdCannotBeBlank':
       case 'ItemIdTooLong':
       case 'ItemMissing':
+      case 'ItemInvalid':
       case 'ItemTooLarge':
       case 'ItemAlreadyExists':
       case 'ItemDoesNotExist':

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -524,6 +524,7 @@ const insertItem = async (params) => {
       case 'ItemIdCannotBeBlank':
       case 'ItemIdTooLong':
       case 'ItemMissing':
+      case 'ItemCannotBeUndefined':
       case 'ItemTooLarge':
       case 'ItemAlreadyExists':
       case 'UserNotSignedIn':
@@ -543,6 +544,8 @@ const _buildInsertParams = async (database, params) => {
   if (!objectHasOwnProperty(params, 'item')) throw new errors.ItemMissing
 
   const { item, itemId } = params
+
+  if (item === undefined) throw new errors.ItemCannotBeUndefined
 
   if (objectHasOwnProperty(params, 'itemId')) {
     if (typeof itemId !== 'string') throw new errors.ItemIdMustBeString
@@ -586,6 +589,7 @@ const updateItem = async (params) => {
       case 'ItemIdCannotBeBlank':
       case 'ItemIdTooLong':
       case 'ItemMissing':
+      case 'ItemCannotBeUndefined':
       case 'ItemTooLarge':
       case 'ItemDoesNotExist':
       case 'ItemUpdateConflict':
@@ -607,6 +611,8 @@ const _buildUpdateParams = async (database, params) => {
   if (!objectHasOwnProperty(params, 'itemId')) throw new errors.ItemIdMissing
 
   const { item, itemId } = params
+
+  if (item === undefined) throw new errors.ItemCannotBeUndefined
 
   if (typeof itemId !== 'string') throw new errors.ItemIdMustBeString
   if (itemId.length === 0) throw new errors.ItemIdCannotBeBlank

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -226,7 +226,7 @@ class OperationsExceedLimit extends Error {
 
     this.name = 'OperationsExceedLimit'
     this.message = `Operations exceed limit. Only allowed ${limit} operations.`
-    this.status = statusCodes['Conflict']
+    this.status = statusCodes['Bad Request']
   }
 }
 

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -90,12 +90,12 @@ class ItemMissing extends Error {
   }
 }
 
-class ItemCannotBeUndefined extends Error {
+class ItemInvalid extends Error {
   constructor(...params) {
     super(...params)
 
-    this.name = 'ItemCannotBeUndefined'
-    this.message = 'Item cannot be undefined.'
+    this.name = 'ItemInvalid'
+    this.message = 'Item must be serializable to JSON.'
     this.status = statusCodes['Bad Request']
   }
 }
@@ -240,7 +240,7 @@ export default {
   ChangeHandlerMustBeFunction,
   DatabaseNotOpen,
   ItemMissing,
-  ItemCannotBeUndefined,
+  ItemInvalid,
   ItemTooLarge,
   ItemIdMustBeString,
   ItemIdTooLong,

--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -90,6 +90,16 @@ class ItemMissing extends Error {
   }
 }
 
+class ItemCannotBeUndefined extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'ItemCannotBeUndefined'
+    this.message = 'Item cannot be undefined.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 class ItemTooLarge extends Error {
   constructor(maxKb, ...params) {
     super(maxKb, ...params)
@@ -230,6 +240,7 @@ export default {
   ChangeHandlerMustBeFunction,
   DatabaseNotOpen,
   ItemMissing,
+  ItemCannotBeUndefined,
   ItemTooLarge,
   ItemIdMustBeString,
   ItemIdTooLong,


### PR DESCRIPTION
If the item provided to insertItem(), updateItem(), or putTransaction() is not serializable to JSON (in other words, `JSON.stringify(item) === undefined`), then the function throws `ItemInvalid`. See [this link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Description) for further discussion on what is serializable to JSON.

- also added tests for putTransaction() in this PR