### PR TITLE
Add GetUser Admin API

### DIFF
--- a/src/userbase-server/admin-panel/App.jsx
+++ b/src/userbase-server/admin-panel/App.jsx
@@ -36,6 +36,7 @@ export default class App extends Component {
     if (signedIn) {
       try {
         paymentStatus = await adminLogic.getPaymentStatus()
+        this.handleReadHash()
 
         if (this.state.signedIn && paymentStatus === 'past_due') {
           window.alert('Please update your payment method!')

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -238,12 +238,13 @@ const resumeSaasSubscription = async () => {
 
 const getPaymentStatus = async () => {
   try {
-    const paymentStatusResponse = await axios({
+    const adminAccountResponse = await axios({
       method: 'GET',
-      url: `/${VERSION}/admin/payment-status`,
+      url: `/${VERSION}/admin/account`,
       timeout: TEN_SECONDS_MS
     })
-    const paymentStatus = paymentStatusResponse.data
+    const { paymentStatus, email, fullName } = adminAccountResponse.data
+    updateLocalSession(email, fullName)
     return paymentStatus
   } catch (e) {
     errorHandler(e)

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -250,6 +250,20 @@ const getPaymentStatus = async () => {
   }
 }
 
+const getAccessToken = async () => {
+  try {
+    const accessTokenResponse = await axios({
+      method: 'GET',
+      url: `/access-tokens`,
+      timeout: TEN_SECONDS_MS
+    })
+    const accessToken = accessTokenResponse.data[0]['access-token'] // always returns a single access token for now
+    return accessToken
+  } catch (e) {
+    errorHandler(e)
+  }
+}
+
 export default {
   createAdmin,
   createApp,
@@ -265,5 +279,6 @@ export default {
   updateSaasPaymentMethod,
   cancelSaasSubscription,
   resumeSaasSubscription,
-  getPaymentStatus
+  getPaymentStatus,
+  getAccessToken,
 }

--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -33,7 +33,7 @@ export default class AppUsersTable extends Component {
       const { users, appId } = await dashboardLogic.listAppUsers(appName)
 
       // sort by date in descending order
-      const appUsers = users.sort((a, b) => new Date(b['creation-date']) - new Date(a['creation-date']))
+      const appUsers = users.sort((a, b) => new Date(b['creationDate']) - new Date(a['creationDate']))
 
       const activeUsers = []
       const deletedUsers = []
@@ -42,7 +42,7 @@ export default class AppUsersTable extends Component {
         const appUser = appUsers[i]
 
         try {
-          appUser['formattedCreationDate'] = new Date(appUser['creation-date'])
+          appUser['formattedCreationDate'] = new Date(appUser['creationDate'])
             .toLocaleDateString([], {
               month: 'short',
               day: 'numeric',
@@ -53,11 +53,11 @@ export default class AppUsersTable extends Component {
               timeZoneName: 'short'
             })
 
-          if (appUser['formattedCreationDate'] === new Date(appUser['creation-date']).toLocaleDateString()) {
-            appUser['formattedCreationDate'] = appUser['creation-date']
+          if (appUser['formattedCreationDate'] === new Date(appUser['creationDate']).toLocaleDateString()) {
+            appUser['formattedCreationDate'] = appUser['creationDate']
           }
         } catch (e) {
-          appUser['formattedCreationDate'] = appUser['creation-date']
+          appUser['formattedCreationDate'] = appUser['creationDate']
         }
 
         if (appUser['deleted']) deletedUsers.push(appUser)
@@ -93,10 +93,10 @@ export default class AppUsersTable extends Component {
     const { appName } = this.props
     const { activeUsers } = this.state
 
-    const userId = user['user-id']
+    const userId = user['userId']
     const username = user['username']
 
-    const getUserIndex = () => this.state.activeUsers.findIndex((user) => user['user-id'] === userId)
+    const getUserIndex = () => this.state.activeUsers.findIndex((user) => user['userId'] === userId)
 
     try {
       if (window.confirm(`Are you sure you want to delete user '${username}'?`)) {
@@ -115,7 +115,7 @@ export default class AppUsersTable extends Component {
           deletedUser.deleting = undefined
           deletedUser.deleted = true
 
-          let insertionIndex = deletedUsers.findIndex((user) => new Date(deletedUser['creation-date']) > new Date(user['creation-date']))
+          let insertionIndex = deletedUsers.findIndex((user) => new Date(deletedUser['creationDate']) > new Date(user['creationDate']))
           if (insertionIndex === -1) {
             deletedUsers.push(deletedUser)
           } else {
@@ -139,10 +139,10 @@ export default class AppUsersTable extends Component {
     const { appName } = this.props
     const { deletedUsers } = this.state
 
-    const userId = user['user-id']
+    const userId = user['userId']
     const username = user['username']
 
-    const getUserIndex = () => this.state.deletedUsers.findIndex((user) => user['user-id'] === userId)
+    const getUserIndex = () => this.state.deletedUsers.findIndex((user) => user['userId'] === userId)
 
     try {
       if (window.confirm(`Are you sure you want to permanently delete user '${username}'? There is no guarantee the account can be recovered after this.`)) {
@@ -226,7 +226,7 @@ export default class AppUsersTable extends Component {
                       <tbody>
 
                         {activeUsers.map((user) => (
-                          <tr key={user['user-id']} className='border-b mouse:hover:bg-yellow-200 h-8'>
+                          <tr key={user['userId']} className='border-b mouse:hover:bg-yellow-200 h-8'>
                             <td className='px-1 font-light text-left'>{user['username']}</td>
                             <td className='px-1 font-light text-left'>{user['formattedCreationDate']}</td>
                             <td className='px-1 font-light w-8 text-center'>
@@ -271,7 +271,7 @@ export default class AppUsersTable extends Component {
                         <tbody>
 
                           {deletedUsers.map((user) => (
-                            <tr key={user['user-id']} className='border-b mouse:hover:bg-yellow-200 h-8'>
+                            <tr key={user['userId']} className='border-b mouse:hover:bg-yellow-200 h-8'>
                               <td className='px-1 font-light text-left text-red-700'>{user['username']}</td>
                               <td className='px-1 font-light text-left'>{user['formattedCreationDate']}</td>
                               <td className='px-1 font-light w-8 text-center'>

--- a/src/userbase-server/app.js
+++ b/src/userbase-server/app.js
@@ -3,6 +3,7 @@ import connection from './connection'
 import logger from './logger'
 import statusCodes from './statusCodes'
 import setup from './setup'
+import userController from './user'
 
 async function createApp(appName, adminId, appId = uuidv4()) {
   if (!appName || !adminId) throw {
@@ -22,7 +23,6 @@ async function createApp(appName, adminId, appId = uuidv4()) {
       'app-name': trimmedAppName,
       'app-id': appId,
       'creation-date': new Date().toISOString(),
-      'num-users': 0
     }
 
     const params = {
@@ -306,7 +306,7 @@ exports.listAppUsers = async function (req, res) {
     }
 
     return res.status(statusCodes['Success']).send({
-      users,
+      users: users.map(user => userController.buildUserResult(user)),
       appId: app['app-id']
     })
   } catch (e) {

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -412,7 +412,6 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1Admin.post('/change-password', admin.authenticateAdmin, admin.changePassword)
     v1Admin.post('/forgot-password', admin.forgotPassword)
-    v1Admin.put('/internal-profile', admin.authenticateAccessToken, userController.updateInternalProfile)
     v1Admin.get('/payment-status', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
       const subscription = res.locals.subscription
       if (!subscription) return res.end()
@@ -423,6 +422,10 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/stripe/update-saas-payment-session', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.updateSaasSubscriptionPaymentSession)
     v1Admin.post('/stripe/cancel-saas-subscription', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.cancelSaasSubscription)
     v1Admin.post('/stripe/resume-saas-subscription', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.resumeSaasSubscription)
+
+    // Access token endpoints
+    v1Admin.put('/internal-profile', admin.authenticateAccessToken, userController.updateInternalProfile)
+    v1Admin.get('/user', admin.authenticateAccessToken, userController.adminGetUserController)
 
     // internal server used to receive notifications of transactions from peers -- shouldn't be exposed to public
     const internalServer = express()

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -412,10 +412,19 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1Admin.post('/change-password', admin.authenticateAdmin, admin.changePassword)
     v1Admin.post('/forgot-password', admin.forgotPassword)
-    v1Admin.get('/payment-status', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
+    v1Admin.get('/account', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
+      const admin = res.locals.admin
       const subscription = res.locals.subscription
-      if (!subscription) return res.end()
-      return res.send(subscription.cancel_at_period_end ? 'cancel_at_period_end' : subscription.status)
+
+      const result = {
+        email: admin['email'],
+        fullName: admin['full-name'],
+        paymentStatus: subscription
+          ? (subscription.cancel_at_period_end ? 'cancel_at_period_end' : subscription.status)
+          : null
+      }
+
+      return res.send(result)
     })
 
     v1Admin.post('/stripe/create-saas-payment-session', admin.authenticateAdmin, admin.createSaasPaymentSession)

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -418,11 +418,10 @@ async function start(express, app, userbaseConfig = {}) {
 
       const result = {
         email: admin['email'],
-        fullName: admin['full-name'],
-        paymentStatus: subscription
-          ? (subscription.cancel_at_period_end ? 'cancel_at_period_end' : subscription.status)
-          : null
+        fullName: admin['full-name']
       }
+
+      if (subscription) result.paymentStatus = subscription.cancel_at_period_end ? 'cancel_at_period_end' : subscription.status
 
       return res.send(result)
     })


### PR DESCRIPTION
### Overview

Allows an admin to retrieve a user's metadata via a REST endpoint `GET /user {accessToken, appId, userId}`. This enables an admin to see a user's internal profile the admin sets using the feature from #100.

### Additional implementation details of this PR

- displays the access token in the admin panel (additional language likely needed linking to docs)

<img width="1068" alt="Screen Shot 2020-02-14 at 1 49 55 AM" src="https://user-images.githubusercontent.com/26468430/74520453-73b8b080-4ecc-11ea-95e3-99087b4ceb99.png">

- The API both strips away user's detailed data in the response (e.g. the user's salts) & converts the response to camel case (e.g. `internal-profile` to `internalProfile`) before sending to client

Update: also added [this small commit](https://github.com/encrypted-dev/userbase/pull/108/commits/c9dc8739957137ada860f300834886b10af4f443) to fix a totally separate minor bug where the admin's email and full name would not update on page refresh if they were changed on the server by a separate browser session. Threw this in this PR to avoid merge conflicts.