### PR TITLE
Fix plus sign encoding

### DIFF
--- a/cypress/integration/login.spec.js
+++ b/cypress/integration/login.spec.js
@@ -109,4 +109,31 @@ describe('Login - Signup Testing', function () {
     })
   })
 
+  it('Signin with + character in username', function () {
+    cy.getRandomInfoWithParams(null, null, 'none').then((randomInfo) => {
+      cy.window().then((window) => {
+        const { userbase } = window
+        window._userbaseEndpoint = info.endpoint
+        userbase.init({ appId: info.appId })
+
+        randomInfo.username += '+'
+
+        return userbase.signUp(randomInfo).then((user) => {
+          expect(user.username, 'user.username').to.exists
+          expect(user.username, 'user.username to be the one signed up').to.equal(randomInfo.username)
+
+          return userbase.signOut().then(() => {
+            return userbase.signIn(randomInfo).then((loggedInUser) => {
+              expect(loggedInUser.username, 'loggedInUser.username').to.exists
+              expect(loggedInUser.username, 'loggedInUser.username to be the one signed in').to.equal(randomInfo.username)
+
+              return userbase.deleteUser()
+            })
+          })
+        })
+      })
+    })
+
+  })
+
 })

--- a/src/userbase-js/src/api/auth.js
+++ b/src/userbase-js/src/api/auth.js
@@ -26,7 +26,7 @@ const signUp = async (username, passwordToken, publicKey, passwordSalts, keySalt
 const getPasswordSalts = async (username) => {
   const passwordSaltsResponse = await axios({
     method: 'GET',
-    url: `${config.getEndpoint()}/api/auth/get-password-salts?appId=${config.getAppId()}&username=${username}`,
+    url: `${config.getEndpoint()}/api/auth/get-password-salts?appId=${config.getAppId()}&username=${encodeURIComponent(username)}`,
     timeout: TEN_SECONDS_MS
   })
   return passwordSaltsResponse.data

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -119,7 +119,10 @@ const forgotPassword = async (email) => {
     const lowerCaseEmail = email.toLowerCase()
     await axios({
       method: 'POST',
-      url: `/${VERSION}/admin/forgot-password?email=${lowerCaseEmail}`,
+      url: `/${VERSION}/admin/forgot-password`,
+      data: {
+        email: lowerCaseEmail
+      },
       timeout: TEN_SECONDS_MS
     })
   } catch (e) {

--- a/src/userbase-server/admin-panel/components/Dashboard/logic.js
+++ b/src/userbase-server/admin-panel/components/Dashboard/logic.js
@@ -23,7 +23,10 @@ const listAppUsers = async (appName) => {
   try {
     const listAppUsersResponse = await axios({
       method: 'POST',
-      url: `/${VERSION}/admin/list-app-users?appName=${appName}`,
+      url: `/${VERSION}/admin/list-app-users`,
+      data: {
+        appName
+      },
       timeout: TEN_SECONDS_MS
     })
 
@@ -38,7 +41,10 @@ const deleteApp = async (appName) => {
   try {
     await axios({
       method: 'POST',
-      url: `/${VERSION}/admin/delete-app?appName=${appName}`,
+      url: `/${VERSION}/admin/delete-app`,
+      data: {
+        appName
+      },
       timeout: TEN_SECONDS_MS
     })
   } catch (e) {
@@ -50,7 +56,11 @@ const permanentDeleteApp = async (appId, appName) => {
   try {
     await axios({
       method: 'POST',
-      url: `/${VERSION}/admin/permanent-delete-app?appId=${appId}&appName=${appName}`,
+      url: `/${VERSION}/admin/permanent-delete-app`,
+      data: {
+        appId,
+        appName,
+      },
       timeout: TEN_SECONDS_MS
     })
   } catch (e) {

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -465,7 +465,7 @@ const setTempPassword = async (email, tempPassword) => {
 }
 
 exports.forgotPassword = async function (req, res) {
-  const email = req.query.email && req.query.email.toLowerCase()
+  const email = req.body.email && req.body.email.toLowerCase()
 
   if (!email) return res
     .status(statusCodes['Bad Request'])

--- a/src/userbase-server/app.js
+++ b/src/userbase-server/app.js
@@ -165,7 +165,7 @@ exports.deleteApp = async function (req, res) {
     .status(statusCodes['Payment Required'])
     .send('Pay subscription fee to delete an app.')
 
-  const appName = req.query.appName
+  const appName = req.body.appName
 
   const admin = res.locals.admin
   const adminId = admin['admin-id']
@@ -212,8 +212,8 @@ exports.permanentDeleteApp = async function (req, res) {
     .status(statusCodes['Payment Required'])
     .send('Pay subscription fee to permanently delete an app.')
 
-  const appName = req.query.appName
-  const appId = req.query.appId
+  const appName = req.body.appName
+  const appId = req.body.appId
 
   const admin = res.locals.admin
   const adminId = admin['admin-id']
@@ -273,7 +273,7 @@ exports.permanentDeleteApp = async function (req, res) {
 }
 
 exports.listAppUsers = async function (req, res) {
-  const appName = req.query.appName
+  const appName = req.body.appName
 
   const admin = res.locals.admin
   const adminId = admin['admin-id']


### PR DESCRIPTION
### Issue

Usernames containing the "+" character could sign up through the SDK, but could not sign in.

This is because the username was passed as a non-encoded query param to the server, resulting in the "+" converting to a space.

### Fix

This PR fixes this issue in signIn() by encoding the query param before sending it to the server.

This PR also fixes this issue in the admin panel by simply passing all params in the JSON body of each request, rather than as query params.

Special thank you to Luther for reporting this bug.