### PR TITLE
Purge deleted data

### DIFF
--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -6,7 +6,7 @@ import statusCodes from './statusCodes'
 import logger from './logger'
 import appController from './app'
 import userController from './user'
-import { validateEmail, trimReq } from './utils'
+import { validateEmail, trimReq, getTtl } from './utils'
 import stripe from './stripe'
 
 // source: https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Session_Management_Cheat_Sheet.md#session-id-length
@@ -29,7 +29,8 @@ const createSession = async function (adminId) {
   const session = {
     'session-id': sessionId,
     'admin-id': adminId,
-    'creation-date': new Date().toISOString()
+    'creation-date': new Date().toISOString(),
+    ttl: getTtl(SECONDS_IN_A_DAY),
   }
 
   const params = {

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -386,41 +386,7 @@ exports.permanentDeleteUser = async function (req, res) {
     if (!app || app['deleted']) return res.status(statusCodes['Not Found']).send('App not found')
     if (!user || user['app-id'] !== app['app-id']) return res.status(statusCodes['Not Found']).send('User not found')
 
-    const existingUserParams = {
-      TableName: setup.usersTableName,
-      Key: {
-        username,
-        'app-id': app['app-id']
-      },
-      ConditionExpression: 'attribute_exists(deleted) and #userId = :userId',
-      ExpressionAttributeNames: {
-        '#userId': 'user-id'
-      },
-      ExpressionAttributeValues: {
-        ':userId': userId
-      }
-    }
-
-    const permanentDeletedUserParams = {
-      TableName: setup.deletedUsersTableName,
-      Item: {
-        ...user // still technically can recover user before data is purged, though more difficult
-      },
-      ConditionExpression: 'attribute_not_exists(#userId)',
-      ExpressionAttributeNames: {
-        '#userId': 'user-id'
-      },
-    }
-
-    const transactionParams = {
-      TransactItems: [
-        { Delete: existingUserParams },
-        { Put: permanentDeletedUserParams }
-      ]
-    }
-
-    const ddbClient = connection.ddbClient()
-    await ddbClient.transactWrite(transactionParams).promise()
+    await userController.permanentDelete(user)
 
     return res.end()
   } catch (e) {

--- a/src/userbase-server/purge.js
+++ b/src/userbase-server/purge.js
@@ -1,0 +1,211 @@
+import uuidv4 from 'uuid/v4'
+import logger from './logger'
+import setup from './setup'
+import connection from './connection'
+import connections from './ws'
+import userController from './user'
+
+const MS_IN_A_DAY = 60 * 60 * 24 * 1000
+const TIME_TO_PURGE = 30 * MS_IN_A_DAY
+
+const permanentDeleteDeletedItems = async (items, closeConnectedClients, permanentDelete) => {
+  const permanentDeletePromises = []
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]
+
+    if (item['deleted']) {
+      // closing connected clients guarantees no lingering clients will be able to insert data while purge is under way
+      closeConnectedClients(item)
+
+      if (new Date() - new Date(item['deleted']) > TIME_TO_PURGE) {
+        permanentDeletePromises.push(permanentDelete(item))
+      }
+    }
+  }
+
+  await Promise.all(permanentDeletePromises)
+}
+
+const scanForDeleted = async (TableName, closeConnectedClients, permanentDelete) => {
+  const params = { TableName }
+
+  const ddbClient = connection.ddbClient()
+  let itemsResponse = await ddbClient.scan(params).promise()
+  let items = itemsResponse.Items
+
+  await permanentDeleteDeletedItems(items, closeConnectedClients, permanentDelete)
+
+  // can be optimized with parallel scan
+  while (itemsResponse.LastEvaluatedKey) {
+    params.ExclusiveStartKey = itemsResponse.LastEvaluatedKey
+    itemsResponse = await ddbClient.scan(params).promise()
+    items = itemsResponse.Items
+
+    await permanentDeleteDeletedItems(items, closeConnectedClients, permanentDelete)
+  }
+}
+
+const scanForDeletedUsers = async (purgeId) => {
+  const start = Date.now()
+  const logChildObject = { purgeId }
+  logger.child(logChildObject).info('Scanning for deleted users')
+
+  await scanForDeleted(
+    setup.usersTableName,
+    (user) => connections.closeUsersConnectedClients(user['user-id']),
+    (user) => userController.permanentDelete(user)
+  )
+
+  logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished scanning for deleted users')
+}
+
+const removeTransaction = async (transaction) => {
+  const transactionParams = {
+    TableName: setup.transactionsTableName,
+    Key: {
+      'database-id': transaction['database-id'],
+      'sequence-no': transaction['sequence-no']
+    }
+  }
+
+  const ddbClient = connection.ddbClient()
+  await ddbClient.delete(transactionParams).promise()
+}
+
+const purgeTransactions = async (userDb) => {
+  const start = Date.now()
+  const logChildObject = { userId: userDb['user-id'], databaseId: userDb['database-id'] }
+  logger.child(logChildObject).info('Purging transactions')
+
+  const transactionParams = {
+    TableName: setup.transactionsTableName,
+    KeyConditionExpression: '#dbId = :dbId',
+    ExpressionAttributeNames: {
+      '#dbId': 'database-id',
+    },
+    ExpressionAttributeValues: {
+      ':dbId': userDb['database-id']
+    }
+  }
+
+  const ddbClient = connection.ddbClient()
+  let transactionsResponse = await ddbClient.query(transactionParams).promise()
+  let transactions = transactionsResponse.Items
+
+  await Promise.all(transactions.map(tx => removeTransaction(tx)))
+
+  while (transactionsResponse.LastEvaluatedKey) {
+    transactionParams.ExclusiveStartKey = transactionsResponse.LastEvaluatedKey
+    transactionsResponse = await ddbClient.query(transactionParams).promise()
+    transactions = transactionsResponse.Items
+
+    await Promise.all(transactions.map(tx => removeTransaction(tx)))
+  }
+
+  // delete database before deleting user database to maintain reference in case of failure
+  await ddbClient.delete({
+    TableName: setup.databaseTableName,
+    Key: {
+      'database-id': userDb['database-id']
+    }
+  }).promise()
+
+  await ddbClient.delete({
+    TableName: setup.userDatabaseTableName,
+    Key: {
+      'user-id': userDb['user-id'],
+      'database-name-hash': userDb['database-name-hash']
+    }
+  }).promise()
+
+  logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished purging transactions')
+}
+
+const purgeUser = async (user) => {
+  const start = Date.now()
+  const logChildObject = { userId: user['user-id'], appId: user['app-id'] }
+  logger.child(logChildObject).info('Purging user')
+
+  const userDatabasesParams = {
+    TableName: setup.userDatabaseTableName,
+    KeyConditionExpression: '#userId = :userId',
+    ExpressionAttributeNames: {
+      '#userId': 'user-id',
+    },
+    ExpressionAttributeValues: {
+      ':userId': user['user-id']
+    }
+  }
+
+  const ddbClient = connection.ddbClient()
+  let userDbsResponse = await ddbClient.query(userDatabasesParams).promise()
+  let userDbs = userDbsResponse.Items
+
+  await Promise.all(userDbs.map(userDb => purgeTransactions(userDb)))
+
+  while (userDbsResponse.LastEvaluatedKey) {
+    userDatabasesParams.ExclusiveStartKey = userDbsResponse.LastEvaluatedKey
+    userDbsResponse = await ddbClient.query(userDatabasesParams).promise()
+    userDbs = userDbsResponse.Items
+
+    await Promise.all(userDbs.map(userDb => purgeTransactions(userDb)))
+  }
+
+  await ddbClient.delete({
+    TableName: setup.deletedUsersTableName,
+    Key: {
+      'user-id': user['user-id']
+    }
+  }).promise()
+
+  logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished purging user')
+}
+
+const purgeDeletedUsers = async (purgeId) => {
+  const start = Date.now()
+  const logChildObject = { purgeId }
+  logger.child(logChildObject).info('Purging deleted users')
+
+  const params = {
+    TableName: setup.deletedUsersTableName
+  }
+
+  const ddbClient = connection.ddbClient()
+  let itemsResponse = await ddbClient.scan(params).promise()
+  let items = itemsResponse.Items
+
+  await Promise.all(items.map(user => purgeUser(user)))
+
+  while (itemsResponse.LastEvaluatedKey) {
+    params.ExclusiveStartKey = itemsResponse.LastEvaluatedKey
+    itemsResponse = await ddbClient.scan(params).promise()
+    items = itemsResponse.Items
+
+    await Promise.all(items.map(user => purgeUser(user)))
+  }
+
+  logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished purging deleted users')
+}
+
+const commencePurge = async () => {
+  const start = Date.now()
+  const purgeId = uuidv4()
+  const logChildObject = { purgeId }
+
+  try {
+    logger.child(logChildObject).info('Commencing purge')
+
+    await scanForDeletedUsers(purgeId)
+    await purgeDeletedUsers(purgeId)
+
+    logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished purge')
+  } catch (e) {
+    logger.child({ timeToPurge: Date.now() - start, err: e, ...logChildObject }).warn('Failed purge')
+  }
+}
+
+export default async function () {
+  await commencePurge()
+  setInterval(commencePurge, MS_IN_A_DAY)
+}

--- a/src/userbase-server/purge.js
+++ b/src/userbase-server/purge.js
@@ -116,7 +116,8 @@ const removeDatabase = async (userDb) => {
     }]
   }
 
-  await connection.ddbClient().transactWrite(params).promise()
+  // await connection.ddbClient().transactWrite(params).promise()
+  logger.child(params).info('Log placeholder -- Delete database')
 }
 
 const removeS3DatabaseStates = async (databaseId) => {
@@ -135,7 +136,8 @@ const removeS3DatabaseStates = async (databaseId) => {
     }
   }
 
-  await setup.s3().deleteObjects(deleteParams).promise()
+  // await setup.s3().deleteObjects(deleteParams).promise()
+  logger.child(deleteParams).info('Log placeholder -- deleting S3 states')
 
   while (dbStatesResponse.IsTruncated) {
     params.ContinuationToken = dbStatesResponse.NextContinuationToken
@@ -144,7 +146,8 @@ const removeS3DatabaseStates = async (databaseId) => {
 
     deleteParams.Delete.Objects = dbStatesResponse.Contents.map(dbState => ({ Key: dbState.Key }))
 
-    await setup.s3().deleteObjects(deleteParams).promise()
+    // await setup.s3().deleteObjects(deleteParams).promise()
+    logger.child(deleteParams).info('Log placeholder -- deleting S3 states')
   }
 }
 
@@ -157,8 +160,9 @@ const removeTransaction = async (transaction) => {
     }
   }
 
-  const ddbClient = connection.ddbClient()
-  await ddbClient.delete(transactionParams).promise()
+  // const ddbClient = connection.ddbClient()
+  // await ddbClient.delete(transactionParams).promise()
+  logger.child(transactionParams).info('Log placeholder -- Deleting transaction')
 }
 
 const purgeTransactions = async (userDb) => {
@@ -215,25 +219,26 @@ const purgeUser = async (user) => {
   const action = (userDbs) => Promise.all(userDbs.map(userDb => purgeTransactions(userDb)))
   await ddbWhileLoop(params, ddbQuery, action)
 
-  // should only be present in this table if purging deleted app or admin
-  const deleteFromTable = ddbClient.delete({
-    TableName: setup.usersTableName,
-    Key: {
-      'username': user['username'],
-      'app-id': user['app-id']
-    }
-  }).promise()
+  // // should only be present in this table if purging deleted app or admin
+  // const deleteFromTable = ddbClient.delete({
+  //   TableName: setup.usersTableName,
+  //   Key: {
+  //     'username': user['username'],
+  //     'app-id': user['app-id']
+  //   }
+  // }).promise()
 
-  // should only be present in this table if purging deleted user
-  const deleteFromDeletedTable = ddbClient.delete({
-    TableName: setup.deletedUsersTableName,
-    Key: {
-      'user-id': user['user-id']
-    }
-  }).promise()
+  // // should only be present in this table if purging deleted user
+  // const deleteFromDeletedTable = ddbClient.delete({
+  //   TableName: setup.deletedUsersTableName,
+  //   Key: {
+  //     'user-id': user['user-id']
+  //   }
+  // }).promise()
 
-  // safe to just try and delete from both
-  await Promise.all([deleteFromDeletedTable, deleteFromTable])
+  // // safe to just try and delete from both
+  // await Promise.all([deleteFromDeletedTable, deleteFromTable])
+  logger.child(logChildObject).info('Log placeholder -- Deleting user')
 
   logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished purging user')
 }
@@ -262,37 +267,39 @@ const purgeApp = async (app) => {
   const action = (users) => Promise.all(users.map(user => purgeUser(user)))
   await ddbWhileLoop(params, ddbQuery, action)
 
-  // should only be present in this table if purging deleted admin
-  const deleteFromTable = ddbClient.delete({
-    TableName: setup.appsTableName,
-    Key: {
-      'admin-id': app['admin-id'],
-      'app-name': app['app-name']
-    }
-  }).promise()
+  // // should only be present in this table if purging deleted admin
+  // const deleteFromTable = ddbClient.delete({
+  //   TableName: setup.appsTableName,
+  //   Key: {
+  //     'admin-id': app['admin-id'],
+  //     'app-name': app['app-name']
+  //   }
+  // }).promise()
 
-  // should only be present in this table if purging deleted app
-  const deleteFromDeletedTable = ddbClient.delete({
-    TableName: setup.deletedAppsTableName,
-    Key: {
-      'app-id': app['app-id']
-    }
-  }).promise()
+  // // should only be present in this table if purging deleted app
+  // const deleteFromDeletedTable = ddbClient.delete({
+  //   TableName: setup.deletedAppsTableName,
+  //   Key: {
+  //     'app-id': app['app-id']
+  //   }
+  // }).promise()
 
-  // safe to just try and delete from both
-  await Promise.all([deleteFromDeletedTable, deleteFromTable])
+  // // safe to just try and delete from both
+  // await Promise.all([deleteFromDeletedTable, deleteFromTable])
+  logger.child(logChildObject).info('Log placeholder -- Deleting app')
 
   logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished purging app')
 }
 
 const removeAccessToken = async (accessToken) => {
-  await connection.ddbClient().delete({
-    TableName: setup.adminAccessTokensTableName,
-    Key: {
-      'admin-id': accessToken['admin-id'],
-      'access-token': accessToken['access-token']
-    }
-  }).promise()
+  // await connection.ddbClient().delete({
+  //   TableName: setup.adminAccessTokensTableName,
+  //   Key: {
+  //     'admin-id': accessToken['admin-id'],
+  //     'access-token': accessToken['access-token']
+  //   }
+  // }).promise()
+  logger.child(accessToken).info('Log placeholder -- Deleting access token')
 }
 
 const purgeAccessTokens = async (admin) => {
@@ -341,12 +348,13 @@ const purgeAdmin = async (admin) => {
     purgeApps(admin)
   ])
 
-  await connection.ddbClient().delete({
-    TableName: setup.deletedAdminsTableName,
-    Key: {
-      'admin-id': admin['admin-id']
-    }
-  }).promise()
+  // await connection.ddbClient().delete({
+  //   TableName: setup.deletedAdminsTableName,
+  //   Key: {
+  //     'admin-id': admin['admin-id']
+  //   }
+  // }).promise()
+  logger.child(logChildObject).info('Log placeholder -- Deleting Admin')
 
   logger.child({ timeToPurge: Date.now() - start, ...logChildObject }).info('Finished purging admin')
 }

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -74,16 +74,17 @@ async function start(express, app, userbaseConfig = {}) {
       const userId = res.locals.user['user-id']
       const userPublicKey = res.locals.user['public-key']
       const adminId = res.locals.admin['admin-id']
+      const appId = res.locals.app['app-id']
 
       const clientId = req.query.clientId
 
-      const conn = connections.register(userId, ws, clientId, adminId)
+      const conn = connections.register(userId, ws, clientId, adminId, appId)
       if (conn) {
         const connectionId = conn.id
 
         const { validationMessage, encryptedValidationMessage } = userController.getValidationMessage(userPublicKey)
 
-        logger.child({ userId, connectionId, adminId, route: 'Connection' }).info('Sending Connection over WebSocket')
+        logger.child({ userId, connectionId, adminId, appId, route: 'Connection' }).info('Sending Connection over WebSocket')
         ws.send(JSON.stringify({
           route: 'Connection',
           keySalts: {
@@ -103,7 +104,7 @@ async function start(express, app, userbaseConfig = {}) {
           let logChildObject
 
           try {
-            logChildObject = { userId, connectionId, adminId, clientId, size: msg.length || msg.byteLength }
+            logChildObject = { userId, connectionId, adminId, clientId, appId, size: msg.length || msg.byteLength }
 
             if (msg.length > FOUR_HUNDRED_KB || msg.byteLength > FOUR_HUNDRED_KB) {
               logger.child(logChildObject).warn('Received large message')
@@ -407,7 +408,7 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/list-apps', admin.authenticateAdmin, appController.listApps)
     v1Admin.post('/list-app-users', admin.authenticateAdmin, appController.listAppUsers)
     v1Admin.post('/delete-app', admin.authenticateAdmin, admin.getSaasSubscriptionController, appController.deleteApp)
-    v1Admin.post('/permanent-delete-app', admin.authenticateAdmin, admin.getSaasSubscriptionController, appController.permanentDeleteApp)
+    v1Admin.post('/permanent-delete-app', admin.authenticateAdmin, admin.getSaasSubscriptionController, appController.permanentDeleteAppController)
     v1Admin.post('/delete-user', admin.authenticateAdmin, admin.deleteUser)
     v1Admin.post('/permanent-delete-user', admin.authenticateAdmin, admin.permanentDeleteUser)
     v1Admin.post('/delete-admin', admin.authenticateAdmin, admin.getSaasSubscriptionController, admin.deleteAdmin)

--- a/src/userbase-server/setup.js
+++ b/src/userbase-server/setup.js
@@ -40,6 +40,7 @@ const userDatabaseTableName = resourceNamePrefix + 'user-databases'
 const transactionsTableName = resourceNamePrefix + 'transactions'
 const deletedUsersTableName = resourceNamePrefix + 'deleted-users'
 const deletedAppsTableName = resourceNamePrefix + 'deleted-apps'
+const deletedAdminsTableName = resourceNamePrefix + 'deleted-admins'
 const dbStatesBucketNamePrefix = resourceNamePrefix + 'database-states'
 const secretManagerSecretId = resourceNamePrefix + 'env'
 
@@ -53,6 +54,7 @@ exports.userDatabaseTableName = userDatabaseTableName
 exports.transactionsTableName = transactionsTableName
 exports.deletedUsersTableName = deletedUsersTableName
 exports.deletedAppsTableName = deletedAppsTableName
+exports.deletedAdminsTableName = deletedAdminsTableName
 
 const adminIdIndex = 'AdminIdIndex'
 const accessTokenIndex = 'AccessTokenIndex'
@@ -305,6 +307,18 @@ async function setupDdb() {
     ]
   }
 
+  // the deleted apps table holds a record per deleted app
+  const deletedAdminsTableParams = {
+    TableName: deletedAdminsTableName,
+    BillingMode: 'PAY_PER_REQUEST',
+    AttributeDefinitions: [
+      { AttributeName: 'admin-id', AttributeType: 'S' }
+    ],
+    KeySchema: [
+      { AttributeName: 'admin-id', KeyType: 'HASH' }
+    ]
+  }
+
   logger.info('Creating DynamoDB tables if necessary')
   await Promise.all([
     createTable(ddb, adminTableParams),
@@ -317,6 +331,7 @@ async function setupDdb() {
     createTable(ddb, transactionsTableParams),
     createTable(ddb, deletedUsersTableParams),
     createTable(ddb, deletedAppsTableParams),
+    createTable(ddb, deletedAdminsTableParams),
   ])
 
   logger.info('Setting time to live on tables if necessary')

--- a/src/userbase-server/setup.js
+++ b/src/userbase-server/setup.js
@@ -3,6 +3,7 @@ import os from 'os'
 import logger from './logger'
 import crypto from './crypto'
 import peers from './peers'
+import purge from './purge'
 
 let awsAccountId
 let initialized = false
@@ -119,6 +120,9 @@ exports.init = async function (userbaseConfig) {
   await setupSM()
   await setupSes()
   await setupEc2PeerDiscovery()
+
+  // kick off the interval to purge deleted data
+  purge()
 }
 
 async function setupDdb() {

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -5,7 +5,7 @@ import statusCodes from './statusCodes'
 import responseBuilder from './responseBuilder'
 import crypto from './crypto'
 import logger from './logger'
-import { validateEmail, trimReq, truncateSessionId } from './utils'
+import { validateEmail, trimReq, truncateSessionId, getTtl } from './utils'
 import appController from './app'
 import adminController from './admin'
 
@@ -40,7 +40,8 @@ const createSession = async function (userId, appId) {
     'session-id': sessionId,
     'user-id': userId,
     'app-id': appId,
-    'creation-date': creationDate
+    'creation-date': creationDate,
+    ttl: getTtl(SECONDS_IN_A_DAY),
   }
 
   const params = {
@@ -934,12 +935,14 @@ exports.extendSession = async function (req, res) {
       Key: {
         'session-id': sessionId
       },
-      UpdateExpression: 'set #extendedDate = :extendedDate',
+      UpdateExpression: 'set #extendedDate = :extendedDate, #ttl = :ttl',
       ExpressionAttributeNames: {
-        '#extendedDate': 'extended-date'
+        '#extendedDate': 'extended-date',
+        '#ttl': 'ttl'
       },
       ExpressionAttributeValues: {
-        ':extendedDate': extendedDate
+        ':extendedDate': extendedDate,
+        ':ttl': getTtl(SECONDS_IN_A_DAY)
       }
     }
 

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -673,6 +673,19 @@ exports.getPasswordSaltsController = async function (req, res) {
       }
     }
 
+    const admin = await adminController.findAdminByAdminId(app['admin-id'])
+    if (!admin || admin['deleted']) {
+      throw {
+        status: statusCodes['Unauthorized'],
+        error: {
+          message: 'App ID not valid',
+          deletedAdminId: admin && admin['admin-id'],
+        }
+      }
+    } else {
+      logChildObject.adminId = admin['admin-id']
+    }
+
     const user = await getUser(appId, username.toLowerCase())
     if (!user || user['deleted']) {
       throw {

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -60,6 +60,8 @@ export const trimReq = (req) => ({ id: req.id, url: req.url })
 
 export const truncateSessionId = (sessionId) => typeof sessionId === 'string' && sessionId.substring(0, 8) // limit sensitive logging
 
+export const getTtl = (secondsToLive) => Math.floor(Date.now() / 1000) + secondsToLive
+
 // matches stringToArrayBuffer from userbase-js/Crypto/utils
 // https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String
 export const stringToArrayBuffer = (str) => {

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -72,3 +72,17 @@ export const stringToArrayBuffer = (str) => {
   }
   return buf
 }
+
+export const getMsUntil1AmPst = () => {
+  const time = new Date()
+
+  const UTC_1_AM_HOUR = 9
+
+  if (time.getUTCHours() >= UTC_1_AM_HOUR) {
+    time.setUTCDate(time.getUTCDate() + 1)
+  }
+
+  time.setUTCHours(UTC_1_AM_HOUR, 0, 0, 0)
+
+  return time.getTime() - Date.now()
+}

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -42,12 +42,13 @@ class TokenBucket {
 }
 
 class Connection {
-  constructor(userId, socket, clientId, adminId) {
+  constructor(userId, socket, clientId, adminId, appId) {
     this.userId = userId
     this.socket = socket
     this.clientId = clientId
     this.id = uuidv4()
     this.adminId = adminId
+    this.appId = appId
     this.databases = {}
     this.keyValidated = false
 
@@ -314,9 +315,11 @@ class Connection {
 }
 
 export default class Connections {
-  static register(userId, socket, clientId, adminId) {
+  static register(userId, socket, clientId, adminId, appId) {
     if (!Connections.sockets) Connections.sockets = {}
     if (!Connections.sockets[userId]) Connections.sockets[userId] = {}
+    if (!Connections.sockets[adminId]) Connections.sockets[adminId] = {}
+    if (!Connections.sockets[appId]) Connections.sockets[appId] = {}
 
     if (!Connections.uniqueClients) Connections.uniqueClients = {}
     if (!Connections.uniqueClients[clientId]) {
@@ -327,10 +330,13 @@ export default class Connections {
       return false
     }
 
-    const connection = new Connection(userId, socket, clientId, adminId)
+    const connection = new Connection(userId, socket, clientId, adminId, appId)
 
     Connections.sockets[userId][connection.id] = connection
-    logger.child({ connectionId: connection.id, userId, clientId, adminId }).info('WebSocket connected')
+    Connections.sockets[adminId][connection.id] = userId
+    Connections.sockets[appId][connection.id] = userId
+
+    logger.child({ connectionId: connection.id, userId, clientId, adminId, appId }).info('WebSocket connected')
 
     return connection
   }
@@ -371,11 +377,15 @@ export default class Connections {
   }
 
   static close(connection) {
-    const { userId, id, clientId, adminId } = connection
+    const { userId, id, clientId, adminId, appId } = connection
     const connectionId = id
 
-    logger.child({ userId, connectionId, clientId, adminId }).info('WebSocket closing')
+    logger.child({ userId, connectionId, clientId, adminId, appId }).info('WebSocket closing')
+
     delete Connections.sockets[userId][connectionId]
+    delete Connections.sockets[adminId][connectionId]
+    delete Connections.sockets[appId][connectionId]
+
     delete Connections.uniqueClients[clientId]
   }
 
@@ -383,7 +393,23 @@ export default class Connections {
     if (!Connections.sockets || !Connections.sockets[userId]) return
 
     for (const conn of Object.values(Connections.sockets[userId])) {
-      this.close(conn)
+      conn.socket.close()
+    }
+  }
+
+  static closeAppsConnectedClients(appId) {
+    if (!Connections.sockets || !Connections.sockets[appId]) return
+
+    for (const userId of Object.values(Connections.sockets[appId])) {
+      this.closeUsersConnectedClients(userId)
+    }
+  }
+
+  static closeAdminsConnectedClients(adminId) {
+    if (!Connections.sockets || !Connections.sockets[adminId]) return
+
+    for (const userId of Object.values(Connections.sockets[adminId])) {
+      this.closeUsersConnectedClients(userId)
     }
   }
 }

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -378,4 +378,12 @@ export default class Connections {
     delete Connections.sockets[userId][connectionId]
     delete Connections.uniqueClients[clientId]
   }
+
+  static closeUsersConnectedClients(userId) {
+    if (!Connections.sockets || !Connections.sockets[userId]) return
+
+    for (const conn of Object.values(Connections.sockets[userId])) {
+      this.close(conn)
+    }
+  }
 }


### PR DESCRIPTION
### Overview

The purge process gets scheduled to run at a random time between 1am and 3am PST every night.

The process starts by scanning the admin, app, and user tables to see if items have been deleted for more than 30 days. If an item has been deleted for more than 30 days, the process places the item in its respective "deleted" table, thereby scheduling it for deletion. For example, if a user has been deleted for 31 days, the purge process will place it in the deleted-users table.

The purge process then scans the "deleted" tables and purges deleted items.

For now, the purge process does not actually remove deleted data; instead, it logs the exact data that will be deleted. Once the logs confirm the code is executing correctly in prod, we plan to uncomment the code that actually removes deleted data.

#### Purge User

When a user is purged, the purge process will iterate over all of the users' databases, delete each database's transactions & S3 database states, then delete the databases, then delete the user.

#### Purge App

When an app is purged, the purge process will first iterate over all of the app's users, purge each user, then delete the app.

#### Purge Admin

When an admin is purged, the purge process will both:

1. iterate over all of the admin's apps and purge each app.
2. delete all of the admin's access tokens.

Then it will delete the admin.

### Notes

- I added TTL's using DDB's TTL feature to the sessions table. This will work for all future sessions, but old sessions prior to this change will still linger. They can be cleaned up with a DDB script.
- When the purge process finds a deleted item in a table, it will close all clients connected to that deleted item. For example, if the purge process finds a deleted app, it will close all clients connected to that app on that server.
- As discussed, there are edge cases where the following can occur:

1. A deleted user's database and transaction data remain even after the purge process completes.
2. Clients can still remain open even after items are deleted.

We plan to solve the 1st edge case in the future with a garbage collector.

We plan to solve the 2nd edge case in the future when we enable revoking access to shared databases & user suspension.