### PR TITLE
Window undefined on Gatsby build creates problems

### DIFF
--- a/src/userbase-js/src/config.js
+++ b/src/userbase-js/src/config.js
@@ -4,7 +4,6 @@ const VERSION = '/v1'
 const DEFAULT_ENDPOINT = 'https://v1.userbase.com' + VERSION
 
 let userbaseAppId = null
-window._userbaseEndpoint = DEFAULT_ENDPOINT
 
 const REMEMBER_ME_OPTIONS = {
   local: true,
@@ -17,7 +16,9 @@ const getAppId = () => {
   return userbaseAppId
 }
 
-const getEndpoint = () => window._userbaseEndpoint
+const getEndpoint = () => {
+  return window._userbaseEndpoint || DEFAULT_ENDPOINT
+}
 
 const setAppId = (appId) => {
   if (userbaseAppId && userbaseAppId !== appId) throw new errors.AppIdAlreadySet(userbaseAppId)


### PR DESCRIPTION
The userbase framework is not called until it is in the browser, but it is imported during the building of the static assets in Gatsby making it problematic to set values on window.

Read more in [Gatsby docs](https://www.gatsbyjs.org/docs/debugging-html-builds/#fixing-third-party-modules).

Userbase is a great framework for Gatsby and would probably benefit from supporting it.