### PR TITLE
[fix] Server ensures user has db open before allowing writes

### DIFF
--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -196,6 +196,7 @@ async function start(express, app, userbaseConfig = {}) {
                     response = await db.doCommand(
                       action,
                       userId,
+                      connectionId,
                       params.dbNameHash,
                       params.dbId,
                       params.itemKey,
@@ -204,11 +205,11 @@ async function start(express, app, userbaseConfig = {}) {
                     break
                   }
                   case 'BatchTransaction': {
-                    response = await db.batchTransaction(userId, params.dbNameHash, params.dbId, params.operations)
+                    response = await db.batchTransaction(userId, connectionId, params.dbNameHash, params.dbId, params.operations)
                     break
                   }
                   case 'Bundle': {
-                    response = await db.bundleTransactionLog(params.dbId, params.seqNo, params.bundle)
+                    response = await db.bundleTransactionLog(userId, connectionId, params.dbId, params.seqNo, params.bundle)
                     break
                   }
                   case 'GetPasswordSalts': {

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -350,6 +350,14 @@ export default class Connections {
     return true
   }
 
+  static isDatabaseOpen(userId, connectionId, databaseId) {
+    if (!Connections.sockets || !Connections.sockets[userId] || !Connections.sockets[userId][connectionId]) return
+
+    const conn = Connections.sockets[userId][connectionId]
+
+    return conn.databases[databaseId] ? true : false
+  }
+
   static push(transaction, userId) {
     if (!Connections.sockets || !Connections.sockets[userId]) return
 


### PR DESCRIPTION
- prevents malicious client from providing another user's database id
- relies on openDatabase, which makes sure that user has access to database before opening it