### PR TITLE
Add ability to generate & delete access token + hash it before storage

### DIFF
--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -254,15 +254,52 @@ const getPaymentStatus = async () => {
   }
 }
 
-const getAccessToken = async () => {
+const getAccessTokens = async () => {
   try {
     const accessTokenResponse = await axios({
       method: 'GET',
-      url: `/access-tokens`,
+      url: `/${VERSION}/admin/access-tokens`,
       timeout: TEN_SECONDS_MS
     })
-    const accessToken = accessTokenResponse.data[0]['access-token'] // always returns a single access token for now
-    return accessToken
+
+    const accessTokens = accessTokenResponse.data
+
+    const sortedAccessTokensByDate = accessTokens.sort((a, b) => new Date(b['creationDate']) - new Date(a['creationDate']))
+
+    return sortedAccessTokensByDate
+  } catch (e) {
+    errorHandler(e)
+  }
+}
+
+const generateAccessToken = async (currentPassword, label) => {
+  try {
+    const accessTokenResponse = await axios({
+      method: 'POST',
+      url: `/${VERSION}/admin/access-token`,
+      data: {
+        currentPassword,
+        label
+      },
+      timeout: TEN_SECONDS_MS
+    })
+    return accessTokenResponse.data
+  } catch (e) {
+    errorHandler(e, false)
+  }
+}
+
+const deleteAccessToken = async (label) => {
+  try {
+    const accessTokenResponse = await axios({
+      method: 'DELETE',
+      url: `/${VERSION}/admin/access-token`,
+      data: {
+        label
+      },
+      timeout: TEN_SECONDS_MS
+    })
+    return accessTokenResponse.data
   } catch (e) {
     errorHandler(e)
   }
@@ -284,5 +321,7 @@ export default {
   cancelSaasSubscription,
   resumeSaasSubscription,
   getPaymentStatus,
-  getAccessToken,
+  getAccessTokens,
+  generateAccessToken,
+  deleteAccessToken,
 }

--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons'
 import dashboardLogic from './logic'
 import UnknownError from '../Admin/UnknownError'
+import { formatDate } from '../../utils'
 
 export default class AppUsersTable extends Component {
   constructor(props) {
@@ -41,24 +42,7 @@ export default class AppUsersTable extends Component {
       for (let i = 0; i < appUsers.length; i++) {
         const appUser = appUsers[i]
 
-        try {
-          appUser['formattedCreationDate'] = new Date(appUser['creationDate'])
-            .toLocaleDateString([], {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: 'numeric',
-              minute: 'numeric',
-              second: 'numeric',
-              timeZoneName: 'short'
-            })
-
-          if (appUser['formattedCreationDate'] === new Date(appUser['creationDate']).toLocaleDateString()) {
-            appUser['formattedCreationDate'] = appUser['creationDate']
-          }
-        } catch (e) {
-          appUser['formattedCreationDate'] = appUser['creationDate']
-        }
+        appUser['formattedCreationDate'] = formatDate(appUser['creationDate'])
 
         if (appUser['deleted']) deletedUsers.push(appUser)
         else activeUsers.push(appUser)
@@ -180,7 +164,7 @@ export default class AppUsersTable extends Component {
 
   render() {
     const { appName, paymentStatus } = this.props
-    const { loading, appId, activeUsers, deletedUsers, error, showDeletedUsers } = this.state
+    const { loading, activeUsers, deletedUsers, error, showDeletedUsers } = this.state
 
     return (
       <div className='text-xs sm:text-sm'>

--- a/src/userbase-server/admin-panel/utils.js
+++ b/src/userbase-server/admin-panel/utils.js
@@ -1,0 +1,25 @@
+export const formatDate = (date, long = true) => {
+  try {
+    const format = {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    }
+
+    if (long) {
+      format.hour = 'numeric'
+      format.minute = 'numeric'
+      format.second = 'numeric'
+      format.timeZoneName = 'short'
+    }
+
+    const formattedDate = new Date(date).toLocaleDateString([], format)
+
+    return formattedDate === new Date(date).toLocaleDateString()
+      ? date
+      : formattedDate
+
+  } catch {
+    return date
+  }
+}

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -994,7 +994,6 @@ exports.generateAccessToken = async function (req, res) {
         label,
         'access-token': crypto.sha256.hash(accessToken).toString('base64'),
         'creation-date': creationDate,
-        hashed: true,
       },
       ConditionExpression: 'attribute_not_exists(#adminId)',
       ExpressionAttributeNames: {

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -390,7 +390,6 @@ async function start(express, app, userbaseConfig = {}) {
 
     // Userbase admin API
     app.use(express.static(path.join(__dirname + adminPanelDir)))
-    app.get('/access-tokens', cookieParser(), admin.authenticateAdmin, admin.getAccessTokens)
     const v1Admin = express.Router()
     app.use('/v1/admin', v1Admin)
 
@@ -415,6 +414,9 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/update-admin', admin.authenticateAdmin, admin.updateAdmin)
     v1Admin.post('/change-password', admin.authenticateAdmin, admin.changePassword)
     v1Admin.post('/forgot-password', admin.forgotPassword)
+    v1Admin.get('/access-tokens', admin.authenticateAdmin, admin.getAccessTokens)
+    v1Admin.post('/access-token', admin.authenticateAdmin, admin.generateAccessToken)
+    v1Admin.delete('/access-token', admin.authenticateAdmin, admin.deleteAccessToken)
     v1Admin.get('/account', admin.authenticateAdmin, admin.getSaasSubscriptionController, (req, res) => {
       const admin = res.locals.admin
       const subscription = res.locals.subscription

--- a/src/userbase-server/setup.js
+++ b/src/userbase-server/setup.js
@@ -59,6 +59,7 @@ const userIdIndex = 'UserIdIndex'
 const appIdIndex = 'AppIdIndex'
 
 exports.adminIdIndex = adminIdIndex
+exports.accessTokenIndex = accessTokenIndex
 exports.userIdIndex = userIdIndex
 exports.appIdIndex = appIdIndex
 
@@ -150,11 +151,12 @@ async function setupDdb() {
     BillingMode: 'PAY_PER_REQUEST',
     AttributeDefinitions: [
       { AttributeName: 'admin-id', AttributeType: 'S' },
+      { AttributeName: 'label', AttributeType: 'S' },
       { AttributeName: 'access-token', AttributeType: 'S' }
     ],
     KeySchema: [
       { AttributeName: 'admin-id', KeyType: 'HASH' },
-      { AttributeName: 'access-token', KeyType: 'RANGE' }
+      { AttributeName: 'label', KeyType: 'RANGE' }
     ],
     GlobalSecondaryIndexes: [{
       IndexName: accessTokenIndex,


### PR DESCRIPTION
Some touch ups to the admin access token introduced in #100 .

- admins can now generate access tokens and provide a label.
- admins must provide their password to generate an access token.
- admins must save the access token upon creation (the server hashes them before storing, so the admin needs to save the pre-image to the hash).
- admins can now delete access tokens.
- implemented a list view of access tokens table similar to app users.

Here's what it looks like now:

![AccessTokens](https://user-images.githubusercontent.com/26468430/75427933-3ad10080-58fc-11ea-9bca-c1435fd5d697.gif)