### PR TITLE
Throw error if WebCrypto API is unavailable

### DIFF
--- a/src/userbase-js/src/auth.js
+++ b/src/userbase-js/src/auth.js
@@ -453,6 +453,8 @@ const signIn = async (params) => {
 
 const init = async (params) => {
   try {
+    if (!window.crypto.subtle) throw new errors.WebCryptoUnavailable
+
     if (typeof params !== 'object') throw new errors.ParamsMustBeObject
 
     if (!objectHasOwnProperty(params, 'appId')) throw new errors.AppIdMissing
@@ -465,6 +467,7 @@ const init = async (params) => {
   } catch (e) {
 
     switch (e.name) {
+      case 'WebCryptoUnavailable':
       case 'ParamsMustBeObject':
       case 'AppIdMissing':
       case 'AppIdAlreadySet':

--- a/src/userbase-js/src/errors/config.js
+++ b/src/userbase-js/src/errors/config.js
@@ -40,9 +40,20 @@ class AppIdCannotBeBlank extends Error {
   }
 }
 
+class WebCryptoUnavailable extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'WebCryptoUnavailable'
+    this.message = 'The WebCrypto API is unavailable. Please make sure your website uses https.'
+    this.status = statusCodes['Bad Request']
+  }
+}
+
 export default {
   AppIdAlreadySet,
   AppIdMustBeString,
   AppIdMissing,
   AppIdCannotBeBlank,
+  WebCryptoUnavailable,
 }


### PR DESCRIPTION
Chrome requires websites use https when accessing the WebCrypto API. This PR throws the error `WebCryptoUnavailable` in init() if the WebCrypto API is unavailable.

See #125 