### PR TITLE
Admin API added ListUsers & ListApps, GetApp only returns app metadata

### DIFF
--- a/cypress/integration/Admin API/app.spec.js
+++ b/cypress/integration/Admin API/app.spec.js
@@ -1,8 +1,8 @@
 import { getRandomString } from '../../support/utils'
 
 // constructs the next page token same way the server does
-function constructNextPageToken(username, appId) {
-  const lastEvaluatedKeyString = JSON.stringify({ username, 'app-id': appId })
+function constructNextPageToken(object) {
+  const lastEvaluatedKeyString = JSON.stringify(object)
   const nextPageToken = Buffer.from(lastEvaluatedKeyString).toString('base64')
   return nextPageToken
 }
@@ -63,7 +63,9 @@ function createAdmin(testReference) {
         fullName: 'Test Admin'
       }
     })
-    .then(function () {
+    .then(function (adminResponse) {
+      testReference.adminId = adminResponse.body
+
       cy
         .request({
           method: 'POST',
@@ -95,144 +97,31 @@ describe('GetApp', function () {
   const APP_ENDPOINT = endpoint + '/admin/apps/'
   const DELETE_ADMIN_ENDPOINT = endpoint + '/admin/delete-admin'
 
-  describe('Success Tests', function () {
+  describe('Success Test', function () {
     it('Default behavior', function () {
       createAdmin(this.test).then(function () {
-        const email = 'fake@email.com'
-        const profile = { hello: 'world!' }
+        const {
+          appId,
+          accessToken
+        } = this.test
 
-        signUp(this.test, email, profile).then(function () {
-          const {
-            userId,
-            username,
-            appId,
-            accessToken
-          } = this.test
-
-          cy
-            .request({
-              method: 'GET',
-              url: APP_ENDPOINT + appId,
-              auth: {
-                bearer: accessToken
-              }
-            })
-            .then(function (response) {
-              expect(response.status, 'status').to.eq(200)
-
-              expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
-              expect(response.body.appId, 'app appId').to.eq(appId)
-              expect(response.body.appName, 'app name').to.eq('Trial')
-
-              expect(response.body.users, 'app users').to.have.length(1)
-              const user = response.body.users[0]
-
-              expect(user, 'user keys').to.have.keys(['username', 'userId', 'appId', 'email', 'profile', 'creationDate'])
-              expect(user.username, 'username').to.eq(username)
-              expect(user.userId, 'userId').to.eq(userId)
-              expect(user.appId, 'appId').to.eq(appId)
-              expect(user.email, 'email').to.eq(email)
-              expect(user.profile, 'profile').to.deep.eq(profile)
-
-              cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
-            })
-        })
-      })
-    })
-
-    it('Pagination Token', function () {
-      createAdmin(this.test).then(function () {
-        const email = 'fake@email.com'
-        const profile = { hello: 'world!' }
-
-        // sign up User A
-        signUp(this.test, email, profile).then(function () {
-          const {
-            appId,
-            accessToken
-          } = this.test
-
-          const userIdUserA = this.test.userId
-          const usernameUserA = this.test.username
-
-          // sign up User B
-          signUp(this.test, email, profile).then(function () {
-            const userIdUserB = this.test.userId
-            const usernameUserB = this.test.username
-
-            // get app should return both users
-            cy
-              .request({
-                method: 'GET',
-                url: APP_ENDPOINT + appId,
-                auth: {
-                  bearer: accessToken
-                }
-              })
-              .then(function (response) {
-                expect(response.status, 'status').to.eq(200)
-
-                expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
-                expect(response.body.appId, 'app appId').to.eq(appId)
-                expect(response.body.appName, 'app name').to.eq('Trial')
-
-                expect(response.body.users, 'app users').to.have.length(2)
-
-                let actualUserA, actualUserB, tokenUsername, expectedPaginatedUser
-                if (response.body.users[0].username === usernameUserA) {
-                  actualUserA = response.body.users[0]
-                  actualUserB = response.body.users[1]
-                  tokenUsername = usernameUserA
-                  expectedPaginatedUser = actualUserB
-                } else {
-                  actualUserA = response.body.users[1]
-                  actualUserB = response.body.users[0]
-                  tokenUsername = usernameUserB
-                  expectedPaginatedUser = actualUserA
-                }
-
-                // check users are correct
-                expect(actualUserA, 'user A keys').to.have.keys(['username', 'userId', 'appId', 'email', 'profile', 'creationDate'])
-                expect(actualUserA.username, 'user A username').to.eq(usernameUserA)
-                expect(actualUserA.userId, 'user A userId').to.eq(userIdUserA)
-                expect(actualUserA.appId, 'user A appId').to.eq(appId)
-                expect(actualUserA.email, 'user A email').to.eq(email)
-                expect(actualUserA.profile, 'user A profile').to.deep.eq(profile)
-
-                expect(actualUserB, 'user B keys').to.have.keys(['username', 'userId', 'appId', 'email', 'profile', 'creationDate'])
-                expect(actualUserB.username, 'user B username').to.eq(usernameUserB)
-                expect(actualUserB.userId, 'user B userId').to.eq(userIdUserB)
-                expect(actualUserB.appId, 'user B appId').to.eq(appId)
-                expect(actualUserB.email, 'user B email').to.eq(email)
-                expect(actualUserB.profile, 'user B profile').to.deep.eq(profile)
-
-                const nextPageToken = constructNextPageToken(tokenUsername, appId)
-
-                // get app with next page token should return 1 user
-                cy
-                  .request({
-                    method: 'GET',
-                    url: APP_ENDPOINT + appId + '?nextPageToken=' + nextPageToken,
-                    auth: {
-                      bearer: accessToken
-                    }
-                  })
-                  .then(function (response) {
-                    expect(response.status, 'status').to.eq(200)
-
-                    expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
-                    expect(response.body.appId, 'app appId').to.eq(appId)
-                    expect(response.body.appName, 'app name').to.eq('Trial')
-
-                    expect(response.body.users, 'app users').to.have.length(1)
-
-                    expect(response.body.users[0], 'paginated user').to.deep.equal(expectedPaginatedUser)
-
-                    cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
-                  })
-              })
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + appId,
+            auth: {
+              bearer: accessToken
+            }
           })
-        })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(200)
+
+            expect(response.body, 'app keys').to.have.keys(['appId', 'appName', 'creationDate'])
+            expect(response.body.appId, 'app appId').to.eq(appId)
+            expect(response.body.appName, 'app name').to.eq('Trial')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
       })
     })
   })
@@ -376,12 +265,304 @@ describe('GetApp', function () {
             cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
           })
       })
+    })
+
+  })
+
+})
+
+describe('ListUsers', function () {
+  const { endpoint } = Cypress.env()
+  const APP_ENDPOINT = endpoint + '/admin/apps/'
+  const DELETE_ADMIN_ENDPOINT = endpoint + '/admin/delete-admin'
+
+  describe('Success Tests', function () {
+    it('Default behavior', function () {
+      createAdmin(this.test).then(function () {
+        const email = 'fake@email.com'
+        const profile = { hello: 'world!' }
+
+        signUp(this.test, email, profile).then(function () {
+          const {
+            userId,
+            username,
+            appId,
+            accessToken
+          } = this.test
+
+          cy
+            .request({
+              method: 'GET',
+              url: APP_ENDPOINT + appId + '/users',
+              auth: {
+                bearer: accessToken
+              }
+            })
+            .then(function (response) {
+              expect(response.status, 'status').to.eq(200)
+
+              expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
+              expect(response.body.appId, 'app appId').to.eq(appId)
+              expect(response.body.appName, 'app name').to.eq('Trial')
+
+              expect(response.body.users, 'app users').to.have.length(1)
+              const user = response.body.users[0]
+
+              expect(user, 'user keys').to.have.keys(['username', 'userId', 'appId', 'email', 'profile', 'creationDate'])
+              expect(user.username, 'username').to.eq(username)
+              expect(user.userId, 'userId').to.eq(userId)
+              expect(user.appId, 'appId').to.eq(appId)
+              expect(user.email, 'email').to.eq(email)
+              expect(user.profile, 'profile').to.deep.eq(profile)
+
+              cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+            })
+        })
+      })
+    })
+
+    it('Pagination Token', function () {
+      createAdmin(this.test).then(function () {
+        const email = 'fake@email.com'
+        const profile = { hello: 'world!' }
+
+        // sign up User A
+        signUp(this.test, email, profile).then(function () {
+          const {
+            appId,
+            accessToken
+          } = this.test
+
+          const userIdUserA = this.test.userId
+          const usernameUserA = this.test.username
+
+          // sign up User B
+          signUp(this.test, email, profile).then(function () {
+            const userIdUserB = this.test.userId
+            const usernameUserB = this.test.username
+
+            // list users should return both users
+            cy
+              .request({
+                method: 'GET',
+                url: APP_ENDPOINT + appId + '/users',
+                auth: {
+                  bearer: accessToken
+                }
+              })
+              .then(function (response) {
+                expect(response.status, 'status').to.eq(200)
+
+                expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
+                expect(response.body.appId, 'app appId').to.eq(appId)
+                expect(response.body.appName, 'app name').to.eq('Trial')
+
+                expect(response.body.users, 'app users').to.have.length(2)
+
+                let actualUserA, actualUserB, tokenUsername, expectedPaginatedUser
+                if (response.body.users[0].username === usernameUserA) {
+                  actualUserA = response.body.users[0]
+                  actualUserB = response.body.users[1]
+                  tokenUsername = usernameUserA
+                  expectedPaginatedUser = actualUserB
+                } else {
+                  actualUserA = response.body.users[1]
+                  actualUserB = response.body.users[0]
+                  tokenUsername = usernameUserB
+                  expectedPaginatedUser = actualUserA
+                }
+
+                // check users are correct
+                expect(actualUserA, 'user A keys').to.have.keys(['username', 'userId', 'appId', 'email', 'profile', 'creationDate'])
+                expect(actualUserA.username, 'user A username').to.eq(usernameUserA)
+                expect(actualUserA.userId, 'user A userId').to.eq(userIdUserA)
+                expect(actualUserA.appId, 'user A appId').to.eq(appId)
+                expect(actualUserA.email, 'user A email').to.eq(email)
+                expect(actualUserA.profile, 'user A profile').to.deep.eq(profile)
+
+                expect(actualUserB, 'user B keys').to.have.keys(['username', 'userId', 'appId', 'email', 'profile', 'creationDate'])
+                expect(actualUserB.username, 'user B username').to.eq(usernameUserB)
+                expect(actualUserB.userId, 'user B userId').to.eq(userIdUserB)
+                expect(actualUserB.appId, 'user B appId').to.eq(appId)
+                expect(actualUserB.email, 'user B email').to.eq(email)
+                expect(actualUserB.profile, 'user B profile').to.deep.eq(profile)
+
+                const nextPageToken = constructNextPageToken({ username: tokenUsername, 'app-id': appId })
+
+                // list users with next page token should return 1 user
+                cy
+                  .request({
+                    method: 'GET',
+                    url: APP_ENDPOINT + appId + '/users?nextPageToken=' + nextPageToken,
+                    auth: {
+                      bearer: accessToken
+                    }
+                  })
+                  .then(function (response) {
+                    expect(response.status, 'status').to.eq(200)
+
+                    expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
+                    expect(response.body.appId, 'app appId').to.eq(appId)
+                    expect(response.body.appName, 'app name').to.eq('Trial')
+
+                    expect(response.body.users, 'app users').to.have.length(1)
+
+                    expect(response.body.users[0], 'paginated user').to.deep.equal(expectedPaginatedUser)
+
+                    cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+                  })
+              })
+          })
+        })
+      })
+    })
+  })
+
+  describe('Failure Tests', function () {
+
+    describe('Authorization', function () {
+
+      it('Authorization header missing', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Authorization header missing.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Authorization scheme must be of type Bearer', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              username: 'fake',
+              password: 'fake'
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Authorization scheme must be of type Bearer.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Access token missing', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              bearer: ''
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Access token missing.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Access token is incorrect length', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              bearer: 'test'
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Access token is incorrect length.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Access token invalid', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              bearer: '00000000000000000000000000000000000000000000'
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(401)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Access token invalid.')
+          })
+      })
+
+    })
+
+    describe('ListUsers failures', function () {
+      beforeEach(function () {
+        createAdmin(this.currentTest).then(function () {
+          const email = 'fake@email.com'
+          const profile = { hello: 'world!' }
+          return signUp(this.currentTest, email, profile)
+        })
+      })
+
+      it('App ID is incorrect length', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'a'.repeat(37) + '/users',
+            failOnStatusCode: false,
+            auth: {
+              bearer: this.test.accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('App ID is incorrect length.')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
+      })
+
+      it('App not found', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + '000000000000000000000000000000000000' + '/users',
+            failOnStatusCode: false,
+            auth: {
+              bearer: this.test.accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(404)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('App not found.')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
+      })
 
       it('Next page token as malformed string', function () {
         cy
           .request({
             method: 'GET',
-            url: APP_ENDPOINT + this.test.appId + '?nextPageToken=' + 'string',
+            url: APP_ENDPOINT + this.test.appId + '/users?nextPageToken=' + 'string',
             failOnStatusCode: false,
             auth: {
               bearer: this.test.accessToken
@@ -397,12 +578,12 @@ describe('GetApp', function () {
       })
 
       it('Next page token with no username', function () {
-        const nextPageToken = constructNextPageToken(undefined, this.test.appId)
+        const nextPageToken = constructNextPageToken({ username: undefined, 'app-id': this.test.appId })
 
         cy
           .request({
             method: 'GET',
-            url: APP_ENDPOINT + this.test.appId + '?nextPageToken=' + nextPageToken,
+            url: APP_ENDPOINT + this.test.appId + '/users?nextPageToken=' + nextPageToken,
             failOnStatusCode: false,
             auth: {
               bearer: this.test.accessToken
@@ -424,7 +605,7 @@ describe('GetApp', function () {
         cy
           .request({
             method: 'GET',
-            url: APP_ENDPOINT + this.test.appId + '?nextPageToken=' + nextPageToken,
+            url: APP_ENDPOINT + this.test.appId + '/users?nextPageToken=' + nextPageToken,
             failOnStatusCode: false,
             auth: {
               bearer: this.test.accessToken
@@ -440,12 +621,284 @@ describe('GetApp', function () {
       })
 
       it('Next page token with incorrect app ID', function () {
-        const nextPageToken = constructNextPageToken(this.test.username, '000000000000000000000000000000000000')
+        const nextPageToken = constructNextPageToken({ username: this.test.username, 'app-id': '000000000000000000000000000000000000' })
 
         cy
           .request({
             method: 'GET',
-            url: APP_ENDPOINT + this.test.appId + '?nextPageToken=' + nextPageToken,
+            url: APP_ENDPOINT + this.test.appId + '/users?nextPageToken=' + nextPageToken,
+            failOnStatusCode: false,
+            auth: {
+              bearer: this.test.accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Next page token invalid.')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
+      })
+    })
+
+  })
+
+})
+
+describe('ListApps', function () {
+  const { endpoint } = Cypress.env()
+  const APP_ENDPOINT = endpoint + '/admin/apps/'
+  const DELETE_ADMIN_ENDPOINT = endpoint + '/admin/delete-admin'
+
+  describe('Success Tests', function () {
+    it('Default behavior', function () {
+      createAdmin(this.test).then(function () {
+        const {
+          appId,
+          accessToken
+        } = this.test
+
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT,
+            auth: {
+              bearer: accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(200)
+
+            expect(response.body, 'apps response').to.have.keys(['apps'])
+            expect(response.body.apps, 'apps array').to.have.lengthOf(1)
+
+            const app = response.body.apps[0]
+
+            expect(app, 'app keys').to.have.keys(['appId', 'appName', 'creationDate'])
+            expect(app.appId, 'app appId').to.eq(appId)
+            expect(app.appName, 'app name').to.eq('Trial')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
+      })
+    })
+
+    it('Pagination Token', function () {
+      createAdmin(this.test).then(function () {
+        const {
+          appId,
+          accessToken,
+          adminId
+        } = this.test
+
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT,
+            auth: {
+              bearer: accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(200)
+
+            expect(response.body, 'apps response').to.have.keys(['apps'])
+            expect(response.body.apps, 'apps array').to.have.lengthOf(1)
+
+            const app = response.body.apps[0]
+
+            expect(app, 'app keys').to.have.keys(['appId', 'appName', 'creationDate'])
+            expect(app.appId, 'app appId').to.eq(appId)
+            expect(app.appName, 'app name').to.eq('Trial')
+
+            const nextPageToken = constructNextPageToken({ 'admin-id': adminId, 'app-name': 'Trial' })
+
+            cy
+              .request({
+                method: 'GET',
+                url: APP_ENDPOINT + '?nextPageToken=' + nextPageToken,
+                auth: {
+                  bearer: accessToken
+                }
+              })
+              .then(function (response) {
+                expect(response.status, 'status').to.eq(200)
+
+                expect(response.body, 'apps response').to.have.keys(['apps'])
+                expect(response.body.apps, 'apps array').to.have.lengthOf(0)
+
+                cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+              })
+          })
+      })
+    })
+  })
+
+  describe('Failure Tests', function () {
+
+    describe('Authorization', function () {
+
+      it('Authorization header missing', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Authorization header missing.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Authorization scheme must be of type Bearer', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              username: 'fake',
+              password: 'fake'
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Authorization scheme must be of type Bearer.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Access token missing', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              bearer: ''
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Access token missing.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Access token is incorrect length', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              bearer: 'test'
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Access token is incorrect length.')
+            expect(response.headers['www-authenticate']).to.eq('Bearer realm="Acccess to the Admin API"')
+          })
+      })
+
+      it('Access token invalid', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + 'fake-app-id',
+            failOnStatusCode: false,
+            auth: {
+              bearer: '00000000000000000000000000000000000000000000'
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(401)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Access token invalid.')
+          })
+      })
+
+    })
+
+    describe('ListApps failures', function () {
+      beforeEach(function () { createAdmin(this.currentTest) })
+
+      it('Next page token as malformed string', function () {
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + '?nextPageToken=' + 'string',
+            failOnStatusCode: false,
+            auth: {
+              bearer: this.test.accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Next page token invalid.')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
+      })
+
+      it('Next page token with no admin ID', function () {
+        const nextPageToken = constructNextPageToken({ 'admin-id': undefined, 'app-name': 'Trial' })
+
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + '?nextPageToken=' + nextPageToken,
+            failOnStatusCode: false,
+            auth: {
+              bearer: this.test.accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Next page token invalid.')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
+      })
+
+      it('Next page token with extra key', function () {
+        const nextPageToken = constructNextPageToken({ 'admin-id': this.test.adminId, 'app-name': 'Trial', 'extra-key': 'hello' })
+
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + '?nextPageToken=' + nextPageToken,
+            failOnStatusCode: false,
+            auth: {
+              bearer: this.test.accessToken
+            }
+          })
+          .then(function (response) {
+            expect(response.status, 'status').to.eq(400)
+            expect(response.body, 'key').to.have.key('message')
+            expect(response.body.message, 'message').to.eq('Next page token invalid.')
+
+            cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })
+          })
+      })
+
+      it('Next page token with incorrect admin ID', function () {
+        const nextPageToken = constructNextPageToken({ 'admin-id': '000000000000000000000000000000000000', 'app-name': 'Trial' })
+
+        cy
+          .request({
+            method: 'GET',
+            url: APP_ENDPOINT + '?nextPageToken=' + nextPageToken,
             failOnStatusCode: false,
             auth: {
               bearer: this.test.accessToken

--- a/cypress/integration/Admin API/app.spec.js
+++ b/cypress/integration/Admin API/app.spec.js
@@ -300,12 +300,9 @@ describe('ListUsers', function () {
             })
             .then(function (response) {
               expect(response.status, 'status').to.eq(200)
+              expect(response.body, 'list users result keys').to.have.keys(['users'])
+              expect(response.body.users, 'users array').to.have.length(1)
 
-              expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
-              expect(response.body.appId, 'app appId').to.eq(appId)
-              expect(response.body.appName, 'app name').to.eq('Trial')
-
-              expect(response.body.users, 'app users').to.have.length(1)
               const user = response.body.users[0]
 
               expect(user, 'user keys').to.have.keys(['username', 'userId', 'appId', 'email', 'profile', 'creationDate'])
@@ -352,12 +349,8 @@ describe('ListUsers', function () {
               })
               .then(function (response) {
                 expect(response.status, 'status').to.eq(200)
-
-                expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
-                expect(response.body.appId, 'app appId').to.eq(appId)
-                expect(response.body.appName, 'app name').to.eq('Trial')
-
-                expect(response.body.users, 'app users').to.have.length(2)
+                expect(response.body, 'list users result keys').to.have.keys(['users'])
+                expect(response.body.users, 'users array').to.have.length(2)
 
                 let actualUserA, actualUserB, tokenUsername, expectedPaginatedUser
                 if (response.body.users[0].username === usernameUserA) {
@@ -400,13 +393,8 @@ describe('ListUsers', function () {
                   })
                   .then(function (response) {
                     expect(response.status, 'status').to.eq(200)
-
-                    expect(response.body, 'app keys').to.have.keys(['users', 'appId', 'appName', 'creationDate'])
-                    expect(response.body.appId, 'app appId').to.eq(appId)
-                    expect(response.body.appName, 'app name').to.eq('Trial')
-
-                    expect(response.body.users, 'app users').to.have.length(1)
-
+                    expect(response.body, 'paginated users result keys').to.have.keys(['users'])
+                    expect(response.body.users, 'paginated users array').to.have.length(1)
                     expect(response.body.users[0], 'paginated user').to.deep.equal(expectedPaginatedUser)
 
                     cy.request({ method: 'POST', url: DELETE_ADMIN_ENDPOINT })

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -158,7 +158,7 @@ exports.createAdminController = async function (req, res) {
   try {
     const sessionId = await createSession(adminId)
     setSessionCookie(res, sessionId)
-    return res.end()
+    return res.send(adminId)
   } catch (e) {
     logger.error(`Failed to create session for admin ${adminId} with ${e}`)
     return res

--- a/src/userbase-server/app.js
+++ b/src/userbase-server/app.js
@@ -410,10 +410,9 @@ const _nextPageTokenToLastEvaluatedKey = (nextPageToken, validateLastEvaluatedKe
   }
 }
 
-const _buildUsersList = (usersResponse, app) => {
+const _buildUsersList = (usersResponse) => {
   const result = {
     users: usersResponse.Items.map(user => userController.buildUserResult(user)),
-    ..._buildAppResult(app)
   }
 
   if (usersResponse.LastEvaluatedKey) {
@@ -516,7 +515,7 @@ exports.listUsersWithPagination = async function (req, res) {
 
     const usersResponse = await _getUsersQuery(app['app-id'], lastEvaluatedKey)
 
-    const result = _buildUsersList(usersResponse, app)
+    const result = _buildUsersList(usersResponse)
 
     logChildObject.statusCode = statusCodes['Success']
     logger.child(logChildObject).info('Successfully listed users from Admin API')

--- a/src/userbase-server/app.js
+++ b/src/userbase-server/app.js
@@ -79,10 +79,7 @@ exports.createAppController = async function (req, res) {
   }
 }
 
-exports.listApps = async function (req, res) {
-  const admin = res.locals.admin
-  const adminId = admin['admin-id']
-
+const queryForApps = async function (adminId, lastEvaluatedKey) {
   const params = {
     TableName: setup.appsTableName,
     KeyConditionExpression: '#adminId = :adminId',
@@ -94,15 +91,23 @@ exports.listApps = async function (req, res) {
     }
   }
 
-  try {
-    const ddbClient = connection.ddbClient()
+  if (lastEvaluatedKey) params.ExclusiveStartKey = lastEvaluatedKey
 
-    let appsResponse = await ddbClient.query(params).promise()
+  const ddbClient = connection.ddbClient()
+  let appsResponse = await ddbClient.query(params).promise()
+  return appsResponse
+}
+
+exports.listApps = async function (req, res) {
+  const admin = res.locals.admin
+  const adminId = admin['admin-id']
+
+  try {
+    let appsResponse = await queryForApps(adminId)
     let apps = appsResponse.Items
 
     while (appsResponse.LastEvaluatedKey) {
-      params.ExclusiveStartKey = appsResponse.LastEvaluatedKey
-      appsResponse = await ddbClient.query(params).promise()
+      appsResponse = await queryForApps(adminId, appsResponse.LastEvaluatedKey)
       apps.push(...appsResponse.Items)
     }
 
@@ -351,7 +356,7 @@ const _validateAppResponseToGetApp = function (app, adminId, logChildObject) {
   }
 }
 
-const _getAppQuery = async function (appId, lastEvaluatedKey) {
+const _getUsersQuery = async function (appId, lastEvaluatedKey) {
   const params = {
     TableName: setup.usersTableName,
     IndexName: setup.appIdIndex,
@@ -371,39 +376,30 @@ const _getAppQuery = async function (appId, lastEvaluatedKey) {
   return usersResponse
 }
 
-const _buildGetAppResult = function (usersResponse, app) {
-  const users = usersResponse.Items
-
-  const result = {
-    users: users.map(user => userController.buildUserResult(user)),
+const _buildAppResult = (app) => {
+  return {
     appName: app['app-name'],
     appId: app['app-id'],
     deleted: app['deleted'],
     creationDate: app['creation-date'],
   }
-
-  // convert last evaluated key to a base64 string so it does not confuse developer
-  if (usersResponse.LastEvaluatedKey) {
-    const lastEvaluatedKeyString = JSON.stringify(usersResponse.LastEvaluatedKey)
-    const base64LastEvaluatedKey = Buffer.from(lastEvaluatedKeyString).toString('base64')
-    result.nextPageToken = base64LastEvaluatedKey
-  }
-
-  return result
 }
 
-const _getLastEvaluatedKeyFromNextPageToken = (nextPageToken, appId) => {
+// convert last evaluated key to a base64 string so it does not confuse developer
+const _lastEvaluatedKeyToNextPageToken = (lastEvaluatedKey) => {
+  const lastEvaluatedKeyString = JSON.stringify(lastEvaluatedKey)
+  const base64LastEvaluatedKey = Buffer.from(lastEvaluatedKeyString).toString('base64')
+  return base64LastEvaluatedKey
+}
+
+const _nextPageTokenToLastEvaluatedKey = (nextPageToken, validateLastEvaluatedKey) => {
   try {
     if (!nextPageToken) return null
 
     const lastEvaluatedKeyString = Buffer.from(nextPageToken, 'base64').toString('ascii')
     const lastEvaluatedKey = JSON.parse(lastEvaluatedKeyString)
 
-    userController._validateUsernameInput(lastEvaluatedKey.username)
-    _validateAppId(lastEvaluatedKey['app-id'])
-
-    if (appId !== lastEvaluatedKey['app-id']) throw 'Token app ID must match authenticated app ID'
-    if (Object.keys(lastEvaluatedKey).length !== 2) throw 'Token must only have 2 keys'
+    validateLastEvaluatedKey(lastEvaluatedKey)
 
     return lastEvaluatedKey
   } catch {
@@ -412,6 +408,45 @@ const _getLastEvaluatedKeyFromNextPageToken = (nextPageToken, appId) => {
       error: { message: 'Next page token invalid.' }
     }
   }
+}
+
+const _buildUsersList = (usersResponse, app) => {
+  const result = {
+    users: usersResponse.Items.map(user => userController.buildUserResult(user)),
+    ..._buildAppResult(app)
+  }
+
+  if (usersResponse.LastEvaluatedKey) {
+    result.nextPageToken = _lastEvaluatedKeyToNextPageToken(usersResponse.LastEvaluatedKey)
+  }
+
+  return result
+}
+
+const _buildAppsList = (appsResponse) => {
+  const result = {
+    apps: appsResponse.Items.map(app => _buildAppResult(app))
+  }
+
+  if (appsResponse.LastEvaluatedKey) {
+    result.nextPageToken = _lastEvaluatedKeyToNextPageToken(appsResponse.LastEvaluatedKey)
+  }
+
+  return result
+}
+
+const _validateListUsersLastEvaluatedKey = (lastEvaluatedKey, appId) => {
+  userController._validateUsernameInput(lastEvaluatedKey.username)
+  _validateAppId(lastEvaluatedKey['app-id'])
+
+  if (appId !== lastEvaluatedKey['app-id']) throw 'Token app ID must match authenticated app ID'
+  if (Object.keys(lastEvaluatedKey).length !== 2) throw 'Token must only have 2 keys'
+}
+
+const _validateListAppsLastEvaluatedKey = (lastEvaluatedKey, adminId) => {
+  if (adminId !== lastEvaluatedKey['admin-id']) throw 'Token admin ID must match authenticated admin ID'
+  if (!lastEvaluatedKey['app-name']) throw 'Token missing app name'
+  if (Object.keys(lastEvaluatedKey).length !== 2) throw 'Token must only have 2 keys'
 }
 
 const _validateAppId = (appId) => {
@@ -426,13 +461,11 @@ exports.getAppController = async function (req, res) {
   let logChildObject
   try {
     const appId = req.params.appId
-    const nextPageToken = req.query.nextPageToken
 
-    logChildObject = { ...res.locals.logChildObject, appId, nextPageToken }
+    logChildObject = { ...res.locals.logChildObject, appId }
     logger.child(logChildObject).info('Getting app')
 
     _validateAppId(appId)
-    const lastEvaluatedKey = _getLastEvaluatedKeyFromNextPageToken(nextPageToken, appId)
 
     const admin = res.locals.admin
     const adminId = admin['admin-id']
@@ -440,9 +473,7 @@ exports.getAppController = async function (req, res) {
     const app = await getAppByAppId(appId)
     _validateAppResponseToGetApp(app, adminId, logChildObject)
 
-    const usersResponse = await _getAppQuery(app['app-id'], lastEvaluatedKey)
-
-    const result = _buildGetAppResult(usersResponse, app)
+    const result = _buildAppResult(app)
 
     logChildObject.statusCode = statusCodes['Success']
     logger.child(logChildObject).info('Successfully got app')
@@ -450,6 +481,87 @@ exports.getAppController = async function (req, res) {
     return res.status(statusCodes['Success']).send(result)
   } catch (e) {
     const message = 'Failed to get app for admin.'
+
+    if (e.status && e.error) {
+      logger.child({ ...logChildObject, statusCode: e.status, err: e.error }).info(message)
+      return res.status(e.status).send(e.error)
+    } else {
+      const statusCode = statusCodes['Internal Server Error']
+      logger.child({ ...logChildObject, statusCode, err: e, }).error(message)
+      return res.status(statusCode).send({ message })
+    }
+  }
+}
+
+exports.listUsersWithPagination = async function (req, res) {
+  let logChildObject
+  try {
+    const appId = req.params.appId
+    const nextPageToken = req.query.nextPageToken
+
+    logChildObject = { ...res.locals.logChildObject, appId, nextPageToken }
+    logger.child(logChildObject).info('Listing users from Admin API')
+
+    _validateAppId(appId)
+    const lastEvaluatedKey = _nextPageTokenToLastEvaluatedKey(
+      nextPageToken,
+      (lastEvaluatedKey) => _validateListUsersLastEvaluatedKey(lastEvaluatedKey, appId)
+    )
+
+    const admin = res.locals.admin
+    const adminId = admin['admin-id']
+
+    const app = await getAppByAppId(appId)
+    _validateAppResponseToGetApp(app, adminId, logChildObject)
+
+    const usersResponse = await _getUsersQuery(app['app-id'], lastEvaluatedKey)
+
+    const result = _buildUsersList(usersResponse, app)
+
+    logChildObject.statusCode = statusCodes['Success']
+    logger.child(logChildObject).info('Successfully listed users from Admin API')
+
+    return res.status(statusCodes['Success']).send(result)
+  } catch (e) {
+    const message = 'Failed to list users.'
+
+    if (e.status && e.error) {
+      logger.child({ ...logChildObject, statusCode: e.status, err: e.error }).info(message)
+      return res.status(e.status).send(e.error)
+    } else {
+      const statusCode = statusCodes['Internal Server Error']
+      logger.child({ ...logChildObject, statusCode, err: e, }).error(message)
+      return res.status(statusCode).send({ message })
+    }
+  }
+}
+
+exports.listAppsWithPagination = async function (req, res) {
+  let logChildObject
+  try {
+    const nextPageToken = req.query.nextPageToken
+
+    logChildObject = { ...res.locals.logChildObject, nextPageToken }
+    logger.child(logChildObject).info('Listing apps from Admin API')
+
+    const admin = res.locals.admin
+    const adminId = admin['admin-id']
+
+    const lastEvaluatedKey = _nextPageTokenToLastEvaluatedKey(
+      nextPageToken,
+      (lastEvaluatedKey) => _validateListAppsLastEvaluatedKey(lastEvaluatedKey, adminId)
+    )
+
+    const appsResponse = await queryForApps(adminId, lastEvaluatedKey)
+
+    const result = _buildAppsList(appsResponse)
+
+    logChildObject.statusCode = statusCodes['Success']
+    logger.child(logChildObject).info('Successfully listed apps from Admin API')
+
+    return res.status(statusCodes['Success']).send(result)
+  } catch (e) {
+    const message = 'Failed to list apps.'
 
     if (e.status && e.error) {
       logger.child({ ...logChildObject, statusCode: e.status, err: e.error }).info(message)

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -441,6 +441,8 @@ async function start(express, app, userbaseConfig = {}) {
     v1Admin.post('/users/:userId', admin.authenticateAccessToken, userController.updateProtectedProfile)
     v1Admin.get('/users/:userId', admin.authenticateAccessToken, userController.adminGetUserController)
     v1Admin.get('/apps/:appId', admin.authenticateAccessToken, appController.getAppController)
+    v1Admin.get('/apps/:appId/users', admin.authenticateAccessToken, appController.listUsersWithPagination)
+    v1Admin.get('/apps', admin.authenticateAccessToken, appController.listAppsWithPagination)
     v1Admin.get('/auth-tokens/:authToken', admin.authenticateAccessToken, userController.verifyAuthToken)
 
     // internal server used to receive notifications of transactions from peers -- shouldn't be exposed to public


### PR DESCRIPTION
### Overview

Some final touchups on the Admin API to make it simpler.

- GetApp now only returns app metadata.  
- GetApp from #122 is now referred to as ListUsers. ~No functional changes to this REST endpoint.~ (Update: removed app metadata from ListUsers)
- Added ListApps.

### GetApp

#### Request

```
GET https://v1.userbase.com/v1/admin/apps/:appId
Authorization: Bearer <access token>
```

#### Success Response Body

```
{
    appId,
    appName,
    creationDate: <Date created as ISO string>,
    deleted: <Date deleted as ISO string>,
}
```

### ListUsers

#### Request

```
GET https://v1.userbase.com/v1/admin/apps/:appId?nextPageToken="<explained below>"
Authorization: Bearer <access token>
```

#### Success Response Body

```
{
    users: [{
        userId,
        username,
        email,
        profile,
        protectedProfile,
        creationDate,
        deleted
    }],
    nextPageToken: <Explained below>
}
```

### ListApps

#### Request

```
GET https://v1.userbase.com/v1/admin/apps?nextPageToken="<explained below>"
Authorization: Bearer <access token>
```

#### Success Response Body

```
{
    apps: [{
        appId,
        appName,
        creationDate: <Date created as ISO string>,
        deleted: <Date deleted as ISO string>,
    }],
    nextPageToken: <Explained below>
}
```

### Next Page Token

`nextPageToken` is an optional pagination token. If the Userbase Admin API returns a `nextPageToken` in the response body, it means the developer must provide it in the next request to get the next page of results.

Here is what querying for all of an app's users would look like (reminder, still need to replace access token with your own):

```
const listUsers = async (appId, nextPageToken) => {
  const appResponse = await axios({
    method: 'GET',
    url: 'https://v1.userbase.com/v1/admin/apps/' + appId + (nextPageToken ? '?nextPageToken=' + nextPageToken : ''),
    headers: {
      Authorization: 'Bearer <access token>'
    }
  })
  return appResponse.data
}

const getAllUsers = async (appId) => {
  const users = []
  let usersResponse = await listUsers(appId)
  users.push(...usersResponse.users)

  while (usersResponse.nextPageToken) {
    usersResponse = await listUsers(appId, usersResponse.nextPageToken)
    users.push(...usersResponse.users)
  }

  return users
}

```