### PR TITLE
If user pending deletion, say so in signIn if provided correct password

### DIFF
--- a/src/userbase-js/src/auth.js
+++ b/src/userbase-js/src/auth.js
@@ -342,6 +342,8 @@ const _signInWrapper = async (username, passwordToken) => {
 
     if (e.response && e.response.data === 'Invalid password') {
       throw new errors.UsernameOrPasswordMismatch
+    } else if (e.response && e.response.data === 'User pending deletion') {
+      throw new errors.UserPendingDeletion
     }
 
     throw e
@@ -427,6 +429,7 @@ const signIn = async (params) => {
       case 'ParamsMustBeObject':
       case 'UsernameMissing':
       case 'UsernameOrPasswordMismatch':
+      case 'UserPendingDeletion':
       case 'UsernameCannotBeBlank':
       case 'UsernameTooLong':
       case 'UsernameMustBeString':

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -131,6 +131,16 @@ class UserAlreadySignedIn extends Error {
   }
 }
 
+class UserPendingDeletion extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'UserPendingDeletion'
+    this.message = 'User is pending deletion.'
+    this.status = statusCodes['Forbidden']
+  }
+}
+
 class AppIdNotValid extends Error {
   constructor(...params) {
     super(...params)
@@ -342,6 +352,7 @@ export default {
   PasswordAttemptLimitExceeded,
   UsernameOrPasswordMismatch,
   UserAlreadySignedIn,
+  UserPendingDeletion,
   AppIdNotValid,
   UserNotSignedIn,
   UserNotFound,

--- a/src/userbase-js/src/statusCodes.js
+++ b/src/userbase-js/src/statusCodes.js
@@ -4,6 +4,7 @@ export default {
   'Bad Request': 400,
   'Unauthorized': 401,
   'Payment Required': 402,
+  'Forbidden': 403,
   'Not Found': 404,
   'Conflict': 409,
   'Too Many Requests': 429,


### PR DESCRIPTION
If a user deletes their account and then tries to sign in to the same account, they get the confusing "UsernameOrPasswordMismatch" error. This PR adds the error "UserPendingDeletion" to make it clear that is why the user cannot sign in when providing the correct password after deleting the account.

Shoutout to @rhucle for highlighting this in #134 .