### PR TITLE
Remove core-js imports in ESM build

### DIFF
--- a/src/userbase-js/.babelrc
+++ b/src/userbase-js/.babelrc
@@ -11,9 +11,7 @@
     [
       "@babel/plugin-transform-runtime",
       {
-        "corejs": 3,
-        "useESModules": true,
-        "version": "^7.7.6"
+        "useESModules": true
       }
     ]
   ]


### PR DESCRIPTION
Following #137, also remove core-js imports in the ES module build, which is the one that webpack/rollup bundlers will be using.