### PR TITLE
Remove core-js imports in ESM build

### DIFF
--- a/src/userbase-js/.babelrc
+++ b/src/userbase-js/.babelrc
@@ -11,9 +11,7 @@
     [
       "@babel/plugin-transform-runtime",
       {
-        "corejs": 3,
-        "useESModules": true,
-        "version": "^7.7.6"
+        "useESModules": true
       }
     ]
   ]


### PR DESCRIPTION
This introduces a browserslist configuration file. This will be used by babel plugins to decide what transformations need to be done (and thus reducing bundle size the less browsers need to be targetd) and also by the eslint plugin I added to warn you about features you are using that aren't supported by targeted browsers in your config.

I'd also recommend adding a section to the readme letting users know they need to polyfill Promise if they want it to work in IE.