### PR TITLE
Ad/compat linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 **/node_modules/**
+**/dist/*
 /build/**
 /npm_build/**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3367,6 +3367,12 @@
         "globals": "^11.12.0"
       }
     },
+    "eslint-plugin-es5": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz",
+      "integrity": "sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==",
+      "dev": true
+    },
     "eslint-plugin-react": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1543,6 +1543,12 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
+    "ast-metadata-inferer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz",
+      "integrity": "sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==",
+      "dev": true
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -2156,6 +2162,12 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "caniuse-db": {
+      "version": "1.0.30001038",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001038.tgz",
+      "integrity": "sha512-yeQ2l99M9upOgMIRfZEdes6HuPbQiRZIMBumUwdXeEQz+faSXUZtZ8xeyEdU+TlJckH09M5NtM038sjKsRa2ow==",
       "dev": true
     },
     "caniuse-lite": {
@@ -3320,6 +3332,29 @@
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
           }
+        }
+      }
+    },
+    "eslint-plugin-compat": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.5.1.tgz",
+      "integrity": "sha512-dhfW12vZxxKLEVhrPoblmEopgwpYU2Sd4GdXj5OSfbQ+as9+1aY+S5pqnJYJvXXNWFFJ6aspLkCyk4NMQ/pgtA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.7",
+        "ast-metadata-inferer": "^0.1.1",
+        "browserslist": "^4.8.2",
+        "caniuse-db": "^1.0.30001017",
+        "lodash.memoize": "4.1.2",
+        "mdn-browser-compat-data": "^1.0.3",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -6346,6 +6381,12 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -6451,6 +6492,15 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdn-browser-compat-data": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-1.0.15.tgz",
+      "integrity": "sha512-0jxT4ZqqCzJJfktX9d4NKgfRENy60kFzhVNV0mXNHvlnw8KrMe2cKOlEKs/Bz+odlgO0rRZAxU0OKiptqVhAXg==",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.2"
       }
     },
     "mem": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cypress-skip-and-only-ui": "^1.2.6",
     "eslint": "^6.7.2",
     "eslint-loader": "^3.0.2",
+    "eslint-plugin-compat": "^3.5.1",
     "eslint-plugin-cypress": "^2.7.0",
     "eslint-plugin-react": "^7.16.0",
     "forever": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "eslint-loader": "^3.0.2",
     "eslint-plugin-compat": "^3.5.1",
     "eslint-plugin-cypress": "^2.7.0",
+    "eslint-plugin-es5": "^1.5.0",
     "eslint-plugin-react": "^7.16.0",
     "forever": "^1.0.0",
     "http-server": "^0.12.0",

--- a/src/proof-of-concept/package-lock.json
+++ b/src/proof-of-concept/package-lock.json
@@ -8488,8 +8488,7 @@
     "userbase-js": {
       "version": "file:../userbase-js",
       "requires": {
-        "@babel/runtime-corejs3": "^7.7.6",
-        "axios": "^0.19.0",
+        "@babel/runtime": "^7.9.2",
         "base64-arraybuffer": "^0.2.0",
         "diffie-hellman": "^5.0.3",
         "lz-string": "^1.4.4",
@@ -9288,11 +9287,11 @@
           }
         },
         "@babel/runtime": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "requires": {
-            "regenerator-runtime": "^0.13.2"
+            "regenerator-runtime": "^0.13.4"
           }
         },
         "@babel/runtime-corejs3": {
@@ -14902,9 +14901,9 @@
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         },
         "regenerator-transform": {
           "version": "0.14.1",

--- a/src/userbase-js/.babelrc
+++ b/src/userbase-js/.babelrc
@@ -11,9 +11,7 @@
     [
       "@babel/plugin-transform-runtime",
       {
-        "corejs": 3,
-        "useESModules": true,
-        "version": "^7.7.6"
+        "useESModules": true
       }
     ]
   ]

--- a/src/userbase-js/.browserslistrc
+++ b/src/userbase-js/.browserslistrc
@@ -1,0 +1,8 @@
+ie >= 11
+last 1 Edge version
+last 1 Firefox version
+last 1 Chrome version
+last 1 Safari version
+last 1 iOS version
+last 1 Android version
+last 1 ChromeAndroid version

--- a/src/userbase-js/.browserslistrc
+++ b/src/userbase-js/.browserslistrc
@@ -1,8 +1,6 @@
-ie >= 11
-last 1 Edge version
-last 1 Firefox version
-last 1 Chrome version
-last 1 Safari version
-last 1 iOS version
-last 1 Android version
-last 1 ChromeAndroid version
+Chrome >= 78
+Safari >= 11
+Firefox >= 71
+Edge >= 18
+ChromeAndroid > 79
+iOS >= 13

--- a/src/userbase-js/.eslintrc
+++ b/src/userbase-js/.eslintrc
@@ -1,0 +1,7 @@
+{
+  env: {
+    browser: true,
+    node: true,
+  },
+  extends: ["plugin:compat/recommended"]
+}

--- a/src/userbase-js/.eslintrc
+++ b/src/userbase-js/.eslintrc
@@ -1,7 +1,21 @@
 {
-  env: {
-    browser: true,
-    node: true,
+  "env": {
+    "browser": true,
+    "node": true
   },
-  extends: ["plugin:compat/recommended"]
+  "extends": [
+    "plugin:compat/recommended"
+  ],
+  "plugins": [
+    "es5"
+  ],
+  "rules": {
+    "es5/no-es6-methods": "error",
+    "es5/no-es6-static-methods": "error"
+  },
+  "settings": {
+    "polyfills": [
+      "Promise"
+    ]
+  }
 }

--- a/src/userbase-js/README.md
+++ b/src/userbase-js/README.md
@@ -30,6 +30,18 @@ Check out the [FAQ](https://userbase.com/docs/faq/) for more details.
 ## How do I start?
 The easiest way to start using Userbase is to create a [free Admin account](https://userbase.com) and follow the [Quickstart](https://userbase.com/docs/quickstart/) guide. If you have any questions, or if there's anything we can do to help you with your web app, please [get in touch](https://userbase.com/contact/). Thank you!
 
+## Browser Compatibility
+
+We have tested support for the following browsers:
+
+- Chrome >= 78
+- Safari >= 11
+- Firefox >= 71
+- Chrome Android >= 80
+- Safari iOS >= 13
+
+To support Internet Explorer, you will need to use a Promise polyfill such as [this one](https://github.com/taylorhakes/promise-polyfill).
+
 ## Credits
 The people who made this project a reality:
 - [Daniel Vassallo](https://twitter.com/dvassallo)

--- a/src/userbase-js/package-lock.json
+++ b/src/userbase-js/package-lock.json
@@ -913,16 +913,6 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@babel/runtime-corejs3": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
-      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
-      "dev": true,
-      "requires": {
-        "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.4"
-      }
-    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -2327,12 +2317,6 @@
           "dev": true
         }
       }
-    },
-    "core-js-pure": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
-      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/src/userbase-js/package.json
+++ b/src/userbase-js/package.json
@@ -61,7 +61,6 @@
     "@babel/core": "^7.7.7",
     "@babel/plugin-transform-runtime": "^7.7.6",
     "@babel/preset-env": "^7.7.7",
-    "@babel/runtime-corejs3": "^7.9.2",
     "@size-limit/preset-big-lib": "^2.2.2",
     "dtslint": "^2.0.2",
     "typescript": "^3.7.3",

--- a/src/userbase-js/src/api/auth.js
+++ b/src/userbase-js/src/api/auth.js
@@ -129,7 +129,7 @@ const getServerPublicKey = async () => {
 
     const method = 'GET'
     const url = `${config.getEndpoint()}/api/auth/server-public-key`
-    const timeout = timeout
+    const timeout = TEN_SECONDS_MS
     const responseType = 'arraybuffer'
 
     xhr.open(method, url)

--- a/src/userbase-js/src/auth.js
+++ b/src/userbase-js/src/auth.js
@@ -22,7 +22,7 @@ const _parseGenericErrors = (e) => {
     } else if (e.response.status === statusCodes['Gateway Timeout']) {
       throw new errors.Timeout
     }
-  } else if (e.message && e.message.includes('timeout')) {
+  } else if (e.message && e.message.indexOf('timeout') !== -1) {
     throw new errors.Timeout
   }
 }

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -24,7 +24,7 @@ const _parseGenericErrors = (e) => {
     } else if (e.response.status === statusCodes['Gateway Timeout']) {
       throw new errors.Timeout
     }
-  } else if (e.message && e.message.includes('timeout')) {
+  } else if (e.message && e.message.indexOf('timeout') !== -1) {
     throw new errors.Timeout
   }
 }

--- a/src/userbase-js/src/utils.js
+++ b/src/userbase-js/src/utils.js
@@ -1,7 +1,3 @@
-export const getSecondsSinceT0 = (t0) => {
-  return `${((performance.now() - t0) / 1000).toFixed(2)}`
-}
-
 export const readArrayBufferAsString = (arrayBuffer) => {
   return new Promise(resolve => {
     let reader = new FileReader()


### PR DESCRIPTION
This introduces a browserslist configuration file. This will be used by babel plugins to decide what transformations need to be done (and thus reducing bundle size the less browsers need to be targetd) and also by the eslint plugin I added to warn you about features you are using that aren't supported by targeted browsers in your config.

I'd also recommend adding a section to the readme letting users know they need to polyfill Promise if they want it to work in IE.