### PR TITLE
Removed ProfileKeyMustBeString error from userbase-js

### DIFF
--- a/src/userbase-js/src/auth.js
+++ b/src/userbase-js/src/auth.js
@@ -77,9 +77,6 @@ const _parseUserResponseError = (e, username) => {
       case 'ProfileMustBeObject':
         throw new errors.ProfileMustBeObject
 
-      case 'ProfileKeyMustBeString':
-        throw new errors.ProfileKeyMustBeString(data.key)
-
       case 'ProfileKeyTooLong':
         throw new errors.ProfileKeyTooLong(data.maxLen, data.key)
 
@@ -218,8 +215,6 @@ const _validateProfile = (profile) => {
   for (const key in profile) {
     keyExists = true
 
-    if (typeof key !== 'string') throw new errors.ProfileKeyMustBeString(key)
-
     const value = profile[key]
     if (typeof value !== 'string') throw new errors.ProfileValueMustBeString(key, value)
     if (!value) throw new errors.ProfileValueCannotBeBlank(key)
@@ -276,7 +271,6 @@ const signUp = async (params) => {
       case 'ProfileMustBeObject':
       case 'ProfileCannotBeEmpty':
       case 'ProfileHasTooManyKeys':
-      case 'ProfileKeyMustBeString':
       case 'ProfileKeyTooLong':
       case 'ProfileValueMustBeString':
       case 'ProfileValueCannotBeBlank':
@@ -638,7 +632,6 @@ const updateUser = async (params) => {
       case 'ProfileMustBeObject':
       case 'ProfileCannotBeEmpty':
       case 'ProfileHasTooManyKeys':
-      case 'ProfileKeyMustBeString':
       case 'ProfileKeyTooLong':
       case 'ProfileValueMustBeString':
       case 'ProfileValueCannotBeBlank':

--- a/src/userbase-js/src/errors/auth.js
+++ b/src/userbase-js/src/errors/auth.js
@@ -221,17 +221,6 @@ class ProfileHasTooManyKeys extends Error {
   }
 }
 
-class ProfileKeyMustBeString extends Error {
-  constructor(key, ...params) {
-    super(key, ...params)
-
-    this.name = 'ProfileKeyMustBeString'
-    this.message = 'Profile key must be a string.'
-    this.status = statusCodes['Bad Request']
-    this.key = key
-  }
-}
-
 class ProfileKeyTooLong extends Error {
   constructor(maxLen, key, ...params) {
     super(maxLen, key, ...params)
@@ -361,7 +350,6 @@ export default {
   ProfileMustBeObject,
   ProfileCannotBeEmpty,
   ProfileHasTooManyKeys,
-  ProfileKeyMustBeString,
   ProfileKeyTooLong,
   ProfileValueMustBeString,
   ProfileValueCannotBeBlank,

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -227,7 +227,6 @@ const _validateProfile = (profile) => {
 
   let counter = 0
   for (const key in profile) {
-    if (typeof key !== 'string') throw { error: 'ProfileKeyMustBeString', message: 'Profile key must be a string.', key }
     if (key.length > MAX_PROFILE_OBJECT_KEY_CHAR_LENGTH) {
       const maxLen = MAX_PROFILE_OBJECT_KEY_CHAR_LENGTH
       throw { error: 'ProfileKeyTooLong', message: `Profile key too long. Must be a max of ${maxLen} characters.`, key, maxLen }


### PR DESCRIPTION
- unnecessary because JS automatically converts object keys to strings ([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_with_Objects))