### PR TITLE
Apps with trial period set now start trial on signUp

### DIFF
--- a/cypress/integration/Admin API/user.spec.js
+++ b/cypress/integration/Admin API/user.spec.js
@@ -394,7 +394,7 @@ describe('UpdateUser', function () {
 
               cy.wrap(null).then(() => {
                 return signIn().then(function (user) {
-                  expect(user, 'keys').to.have.keys(['userId', 'username', 'authToken', 'protectedProfile', 'paymentsMode'])
+                  expect(user, 'keys').to.have.keys(['userId', 'username', 'authToken', 'protectedProfile', 'paymentsMode', 'creationDate'])
 
                   expect(user.userId, 'userId').to.eq(userId)
                   expect(user.username, 'username').to.eq(username)
@@ -648,7 +648,7 @@ describe('UpdateUser', function () {
 
                   cy.wrap(null).then(() => {
                     return signIn().then(function (user) {
-                      expect(user, 'keys').to.have.keys(['userId', 'username', 'authToken', 'paymentsMode'])
+                      expect(user, 'keys').to.have.keys(['userId', 'username', 'authToken', 'paymentsMode', 'creationDate'])
 
                       expect(user.userId, 'userId').to.eq(userId)
                       expect(user.username, 'username').to.eq(username)
@@ -726,7 +726,7 @@ describe('UpdateUser', function () {
 
                   cy.wrap(null).then(() => {
                     return signIn().then(function (user) {
-                      expect(user, 'keys').to.have.keys(['userId', 'username', 'authToken', 'paymentsMode'])
+                      expect(user, 'keys').to.have.keys(['userId', 'username', 'authToken', 'paymentsMode', 'creationDate'])
 
                       expect(user.userId, 'userId').to.eq(userId)
                       expect(user.username, 'username').to.eq(username)

--- a/src/userbase-js/src/db.js
+++ b/src/userbase-js/src/db.js
@@ -427,6 +427,8 @@ const _openDatabase = async (dbNameHash, changeHandler, newDatabaseParams) => {
             throw new errors.SubscribedToIncorrectPlan
           case 'SubscriptionInactive':
             throw new errors.SubscriptionInactive(data.subscriptionStatus)
+          case 'TrialExpired':
+            throw new errors.TrialExpired
         }
 
       }
@@ -505,6 +507,7 @@ const openDatabase = async (params) => {
       case 'SubscriptionNotFound':
       case 'SubscribedToIncorrectPlan':
       case 'SubscriptionInactive':
+      case 'TrialExpired':
       case 'TooManyRequests':
       case 'ServiceUnavailable':
         throw e

--- a/src/userbase-js/src/errors/payments.js
+++ b/src/userbase-js/src/errors/payments.js
@@ -156,6 +156,16 @@ class SubscriptionAlreadyCanceled extends Error {
   }
 }
 
+class TrialExpired extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'TrialExpired'
+    this.message = 'Trial expired. User must purchase a subscription.'
+    this.status = statusCodes['Payment Required']
+  }
+}
+
 class StripeError extends Error {
   constructor(error, ...params) {
     super(error, ...params)
@@ -186,5 +196,6 @@ export default {
   SubscriptionInactive,
   SubscriptionNotPurchased,
   SubscriptionAlreadyCanceled,
+  TrialExpired,
   StripeError,
 }

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -68,7 +68,9 @@ class Connection {
       salts: {}
     }
 
-    this.stripeData = {}
+    this.userData = {
+      stripeData: {}
+    }
 
     this.rememberMe = rememberMe
 
@@ -410,8 +412,8 @@ class Connection {
     this.keys.dhPrivateKey = await crypto.diffieHellman.importKeyFromMaster(masterKey, base64.decode(salts.dhKeySalt))
     this.keys.hmacKey = await crypto.hmac.importKeyFromMaster(masterKey, base64.decode(salts.hmacKeySalt))
 
-    const stripeData = await this.validateKey()
-    this.stripeData = stripeData
+    const userData = await this.validateKey()
+    this.userData = userData
 
     this.keys.init = true
 
@@ -428,8 +430,8 @@ class Connection {
     const params = { validationMessage }
 
     const response = await this.request(action, params)
-    const { stripeData } = response.data
-    return stripeData
+    const userData = response.data
+    return userData
   }
 
   async request(action, params) {

--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -20,7 +20,9 @@ export interface UserResult {
   username: string
   userId: string
   authToken: string
+  creationDate: Date
   paymentsMode: PaymentsMode
+  trialExpirationDate?: Date
   subscriptionStatus?: SubscriptionStatus
   cancelSubscriptionAt?: Date
   email?: string

--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -707,7 +707,6 @@ export default class AppUsersTable extends Component {
                                     }
                                   </h6>
 
-
                                   <h6 className='mb-4'>Protected Profile:
                                     {user['protectedProfile']
                                       ? ProfileTable(user['protectedProfile'])
@@ -716,7 +715,6 @@ export default class AppUsersTable extends Component {
                                       </span>
                                     }
                                   </h6>
-
 
                                   <h6 className='mb-4'>Test Stripe Data:
                                     {user['testStripeData']

--- a/src/userbase-server/admin-panel/components/Dashboard/StripeDataTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/StripeDataTable.jsx
@@ -2,18 +2,28 @@ import React from 'react'
 import { formatDate } from '../../utils'
 
 export const StripeDataTable = (stripeData, isProd) => {
-  const { customerId, subscriptionStatus, cancelSubscriptionAt, subscriptionId, subscriptionPlanId } = stripeData
+  const { customerId, subscriptionStatus, cancelSubscriptionAt, subscriptionId, subscriptionPlanId, trialExpirationDate } = stripeData
 
   return (
     <table className='mt-4 table-auto w-3/4 border border-black mx-auto text-xs'>
       <tbody>
+        {trialExpirationDate &&
+          <tr>
+            <td className='border border-black px-1 font-light text-left'>Trial Expires On</td>
+            <td className='border border-black px-1 font-light text-left'>{formatDate(trialExpirationDate, false)}</td>
+          </tr>
+        }
+
         <tr>
           <td className='border border-black px-1 font-light text-left'>Customer</td>
           <td className='border border-black px-1 font-light text-left'>
-            <a
-              href={'https://dashboard.stripe.com' + (isProd ? '' : '/test') + '/customers/' + customerId}>
-              {customerId}
-            </a>
+            {customerId
+              ? <a
+                href={'https://dashboard.stripe.com' + (isProd ? '' : '/test') + '/customers/' + customerId}>
+                {customerId}
+              </a>
+              : 'No customer saved.'
+            }
           </td>
         </tr>
 
@@ -24,7 +34,7 @@ export const StripeDataTable = (stripeData, isProd) => {
 
         {cancelSubscriptionAt &&
           <tr>
-            <td className='border border-black px-1 font-light text-left'>Cancel Subscription At</td>
+            <td className='border border-black px-1 font-light text-left'>Canceling Subscription On</td>
             <td className='border border-black px-1 font-light text-left'>{formatDate(cancelSubscriptionAt, false)}</td>
           </tr>
         }

--- a/src/userbase-server/setup.js
+++ b/src/userbase-server/setup.js
@@ -61,12 +61,16 @@ const accessTokenIndex = 'AccessTokenIndex'
 const userIdIndex = 'UserIdIndex'
 const appIdIndex = 'AppIdIndex'
 const authTokenIndex = 'AuthTokenIndex'
+const subscriptionPlanIndex = 'SubscriptionPlanIndex'
+const testSubscriptionPlanIndex = 'test' + subscriptionPlanIndex
+const prodSubscriptionPlanIndex = 'prod' + subscriptionPlanIndex
 
 exports.adminIdIndex = adminIdIndex
 exports.accessTokenIndex = accessTokenIndex
 exports.userIdIndex = userIdIndex
 exports.appIdIndex = appIdIndex
 exports.authTokenIndex = authTokenIndex
+exports.subscriptionPlanIndex = subscriptionPlanIndex
 
 const getDbStatesBucketName = function () {
   if (!initialized || !awsAccountId) {
@@ -182,19 +186,37 @@ async function setupDdb() {
     AttributeDefinitions: [
       { AttributeName: 'admin-id', AttributeType: 'S' },
       { AttributeName: 'app-name', AttributeType: 'S' },
-      { AttributeName: 'app-id', AttributeType: 'S' }
+      { AttributeName: 'app-id', AttributeType: 'S' },
+      { AttributeName: 'test-subscription-plan-id', AttributeType: 'S' },
+      { AttributeName: 'prod-subscription-plan-id', AttributeType: 'S' },
     ],
     KeySchema: [
       { AttributeName: 'admin-id', KeyType: 'HASH' },
       { AttributeName: 'app-name', KeyType: 'RANGE' }
     ],
-    GlobalSecondaryIndexes: [{
-      IndexName: appIdIndex,
-      KeySchema: [
-        { AttributeName: 'app-id', KeyType: 'HASH' }
-      ],
-      Projection: { ProjectionType: 'ALL' }
-    }]
+    GlobalSecondaryIndexes: [
+      {
+        IndexName: appIdIndex,
+        KeySchema: [
+          { AttributeName: 'app-id', KeyType: 'HASH' }
+        ],
+        Projection: { ProjectionType: 'ALL' }
+      },
+      {
+        IndexName: testSubscriptionPlanIndex,
+        KeySchema: [
+          { AttributeName: 'test-subscription-plan-id', KeyType: 'HASH' }
+        ],
+        Projection: { ProjectionType: 'ALL' }
+      },
+      {
+        IndexName: prodSubscriptionPlanIndex,
+        KeySchema: [
+          { AttributeName: 'prod-subscription-plan-id', KeyType: 'HASH' }
+        ],
+        Projection: { ProjectionType: 'ALL' }
+      },
+    ]
   }
 
   // the users table holds a record for user per app


### PR DESCRIPTION
### Overview

With #148 , when an admin set a subscription plan with a trial period on an app, a new user signing up to the app would not be able to call `openDatabase` successfully right off the bat. The user would need to call `purchaseSubscription` and provide their credit card in the Stripe Checkout form to begin their trial and successfully call `openDatabase`.

Now, with this PR, when a user signs up for an app with a subscription plan with a trial period set, the user will be able to call `openDatabase` until the trial expires. And when the user calls `purchaseSubscription`, we charge the user immediately, it does not begin a trial.

### Details

The user's `subscriptionStatus` should never be set to 'trialing' now. A developer will know a user is in trial mode because we return `trialExpirationDate` on users. This date is determined in memory by the server using the trial period set on the subscription plan in Stripe and the user's creation date in DDB.

### signUp(), signIn(), and init()

These functions now return the following on the user object:

##### creationDate
##### trialExpirationDate (optional)

## Changes to Admin API

### GetApp

Now returns the following additional additional fields:

##### testTrialPeriodDays
##### prodTrialPeriodDays

### GetUser

On each of these fields,

##### testStripeData
##### prodStripeData

each object has the following additional field:

###### trialExpirationDate

### Note

Before deploying, in addition to the steps highlighted in #148, we’ll also need to add the Stripe subscription plan indexes in DDB.