### PR TITLE
Userbase hompage pricing button links automatically trigger actions

### DIFF
--- a/src/userbase-server/admin-panel/App.jsx
+++ b/src/userbase-server/admin-panel/App.jsx
@@ -117,6 +117,8 @@ export default class App extends Component {
       updatedState.admin = { email }
       updatedState.errorGettingAdmin = false
       updatedState.signedIn = false
+      updatedState.upgrade = false
+      updatedState.enablePayments = false
     }
 
     const hashRoute = window.location.hash.substring(1)
@@ -143,6 +145,15 @@ export default class App extends Component {
       case 'update-success':
         window.alert('Payment method saved!')
         window.location.hash = ''
+        break
+
+      case 'upgrade':
+      case 'enable-payments':
+        // will redirect to edit-account when admin visits this link, then signs in or signs up. Will automatically
+        // simulate clicking the button to perform the action (upgrade or enable payments)
+        if (hashRoute === 'enable-payments') this.setState({ enablePayments: true })
+        else this.setState({ [hashRoute]: true })
+        window.location.hash = 'edit-account'
         break
 
       default:
@@ -173,6 +184,8 @@ export default class App extends Component {
       mobileMenuOpen,
       loadingAdmin,
       errorGettingAdmin,
+      upgrade,
+      enablePayments,
     } = this.state
 
     if (!mode) {
@@ -228,6 +241,8 @@ export default class App extends Component {
                     key='create-admin'
                     placeholderEmail=''
                     handleUpdateAccount={this.handleUpdateAccount}
+                    upgrade={upgrade}
+                    enablePayments={enablePayments}
                   />
 
                 case 'sign-in':
@@ -236,6 +251,8 @@ export default class App extends Component {
                     key='sign-in'
                     placeholderEmail={admin.email}
                     handleUpdateAccount={this.handleUpdateAccount}
+                    upgrade={upgrade}
+                    enablePayments={enablePayments}
                   />
 
                 case 'dashboard':
@@ -253,6 +270,8 @@ export default class App extends Component {
 
                 case 'edit-account':
                   return <EditAdmin
+                    upgrade={upgrade}
+                    enablePayments={enablePayments}
                     handleUpdateAccount={this.handleUpdateAccount}
                     admin={admin}
                   />

--- a/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/AdminForm.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { string, func } from 'prop-types'
+import { string, func, bool } from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck } from '@fortawesome/free-solid-svg-icons'
 import adminLogic from './logic'
@@ -54,7 +54,7 @@ export default class AdminForm extends Component {
   }
 
   async handleSubmit(event) {
-    const { formType, handleUpdateAccount } = this.props
+    const { formType, handleUpdateAccount, upgrade, enablePayments } = this.props
     const { email, password, fullName, receiveEmailUpdates } = this.state
     event.preventDefault()
 
@@ -70,7 +70,7 @@ export default class AdminForm extends Component {
         return console.error('Unknown form type')
       }
 
-      window.location.hash = ''
+      window.location.hash = (upgrade || enablePayments) ? 'edit-account' : ''
     } catch (e) {
       if (this._isMounted) this.setState({ error: e.message, loading: false })
     }
@@ -252,5 +252,7 @@ export default class AdminForm extends Component {
 AdminForm.propTypes = {
   formType: string,
   placeholderEmail: string,
-  handleUpdateAccount: func
+  handleUpdateAccount: func,
+  upgrade: bool,
+  enablePayments: bool,
 }

--- a/src/userbase-server/admin-panel/config.js
+++ b/src/userbase-server/admin-panel/config.js
@@ -24,3 +24,5 @@ export const getStripeState = () => {
 }
 
 export const getStripeCancelWarning = (usePlural) => `\n\nWarning! If you have any customers subscribed to your ${usePlural ? 'apps' : 'app'}, you will need to cancel their subscriptions manually in the Stripe dashboard.`
+
+export const PAYMENTS_ADD_ON_PRICE = 129


### PR DESCRIPTION
The buttons on the [pricing page](https://userbase.com/pricing/) can now link to #upgrade and #enable-payments to automatically trigger the logic for each.

- if admin is not signed in, they can create a new account or sign in, and then the signed in logic is triggered
- if signed in
    - if the admin already has the plan, do nothing
    - if the admin does not have the plan, simulate clicking the respective button

On enable-payments, it displays the modal `window.confirm('Purchase the payments add-on for $129 per year!')` before simulating the button click to buy the add-on.

Unfortunately I couldn't get Chrome to consistently render the #edit-account page before displaying the modal, so it gets stuck in the loading state until the admin responds to the modal. It works consistently in Safari and Firefox.

I could do something really hacky and use setTimeout(100) before simulating the #enable-payment flow to give the page time to render. This works on my computer consistently. Or create a custom modal.

Here's what each looks like:

#### Safari

![Screen Shot 2020-05-07 at 4 14 58 PM](https://user-images.githubusercontent.com/26468430/81353868-0e193200-907f-11ea-88a8-77d192a2d43a.png)

#### Firefox

![Screen Shot 2020-05-07 at 4 15 52 PM](https://user-images.githubusercontent.com/26468430/81353878-15404000-907f-11ea-8a44-94e7cf373b90.png)

#### Chrome

![Screen Shot 2020-05-07 at 4 16 57 PM](https://user-images.githubusercontent.com/26468430/81353891-1e311180-907f-11ea-8305-03294d3fb45a.png)