### PR TITLE
Transition from DH to ECDSA-ECDH

### DIFF
--- a/src/proof-of-concept/client/components/User/logic.js
+++ b/src/proof-of-concept/client/components/User/logic.js
@@ -1,5 +1,7 @@
 import userbase from 'userbase-js'
 
+window.userbase = userbase
+
 const _errorHandler = (e, operation) => {
   console.log(`Failed to ${operation} with`, e)
 

--- a/src/userbase-js/src/Crypto/aes-kw.js
+++ b/src/userbase-js/src/Crypto/aes-kw.js
@@ -1,0 +1,18 @@
+const KEY_TYPE = 'jwk'
+
+const KEY_IS_NOT_EXTRACTABLE = false
+const KEY_WILL_BE_USED_TO = ['wrapKey', 'unwrapKey']
+
+const AES_KW = 'AES-KW'
+const BIT_SIZE = 256
+const AES_KW_PARAMS = {
+  name: AES_KW,
+  length: BIT_SIZE
+}
+
+export default {
+  KEY_TYPE,
+  KEY_IS_NOT_EXTRACTABLE,
+  KEY_WILL_BE_USED_TO,
+  AES_KW_PARAMS,
+}

--- a/src/userbase-js/src/Crypto/ecdh.js
+++ b/src/userbase-js/src/Crypto/ecdh.js
@@ -1,0 +1,106 @@
+import base64 from 'base64-arraybuffer'
+import hkdf from './hkdf'
+import aesKw from './aes-kw'
+import ecdsa from './ecdsa'
+
+const ECDH_ALGORITHM_NAME = 'ECDH'
+const KEY_IS_EXTRACTABLE = true
+const KEY_WILL_BE_USED_TO = ['deriveKey', 'deriveBits']
+const PUBLIC_KEY_TYPE = 'spki'
+
+const ECDH_KEY_WRAPPER = 'ecdh-key-wrapper'
+
+/**
+ * NIST recommendation:
+ *
+ * 128-bit security provided with 256-bit key size
+ *
+ * Pg. 55
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf
+ *
+ **/
+const NAMED_CURVE = 'P-256'
+
+const ECDH_PARAMS = {
+  name: ECDH_ALGORITHM_NAME,
+  namedCurve: NAMED_CURVE
+}
+
+const generateKeyPair = async () => {
+  const keyPair = await window.crypto.subtle.generateKey(
+    ECDH_PARAMS,
+    KEY_IS_EXTRACTABLE,
+    KEY_WILL_BE_USED_TO
+  )
+  return keyPair
+}
+
+const getRawPublicKeyFromPublicKey = async (publicKey) => {
+  const rawPublicKey = await window.crypto.subtle.exportKey(PUBLIC_KEY_TYPE, publicKey)
+  return rawPublicKey
+}
+
+const importEcdhKeyWrapperFromMaster = async (masterKey, salt) => {
+  const keyWrapper = await window.crypto.subtle.deriveKey(
+    hkdf.getParams(ECDH_KEY_WRAPPER, salt),
+    masterKey,
+    aesKw.AES_KW_PARAMS,
+    aesKw.KEY_IS_NOT_EXTRACTABLE,
+    aesKw.KEY_WILL_BE_USED_TO
+  )
+
+  return keyWrapper
+}
+
+const wrapEcdhPrivateKey = async (ecdhPrivateKey, ecdhKeyWrapper) => {
+  const ciphertextArrayBuffer = await window.crypto.subtle.wrapKey(
+    aesKw.KEY_TYPE,
+    ecdhPrivateKey,
+    ecdhKeyWrapper,
+    aesKw.AES_KW_PARAMS
+  )
+
+  return ciphertextArrayBuffer
+}
+
+const unwrapEcdhPrivateKey = async (wrappedEcdhPrivateKey, ecdhKeyWrapper) => {
+  const ecdhPrivateKey = await window.crypto.subtle.unwrapKey(
+    aesKw.KEY_TYPE,
+    wrappedEcdhPrivateKey,
+    ecdhKeyWrapper,
+    aesKw.AES_KW_PARAMS,
+    ECDH_PARAMS,
+    KEY_IS_EXTRACTABLE,
+    KEY_WILL_BE_USED_TO
+  )
+
+  return ecdhPrivateKey
+}
+
+const generateEcdhKeyData = async (masterKey, ecdsaPrivateKey) => {
+  // need to generate new key pair because cannot derive ECDH key pair using HKDF in WebCrypto
+  const ecdhKeyPair = await generateKeyPair()
+
+  // derive a key wrapper using HKDF to wrap the ECDH private key and store it on server
+  const ecdhKeyWrapperSalt = hkdf.generateSalt()
+  const ecdhKeyWrapper = await importEcdhKeyWrapperFromMaster(masterKey, ecdhKeyWrapperSalt)
+  const wrappedEcdhPrivateKey = await wrapEcdhPrivateKey(ecdhKeyPair.privateKey, ecdhKeyWrapper)
+
+  const ecdhPublicKey = await getRawPublicKeyFromPublicKey(ecdhKeyPair.publicKey)
+  const signedEcdhPublicKey = await ecdsa.sign(ecdsaPrivateKey, ecdhPublicKey)
+
+  return {
+    ecdhPrivateKey: ecdhKeyPair.privateKey,
+    ecdhPublicKey: base64.encode(ecdhPublicKey),
+    wrappedEcdhPrivateKey: base64.encode(wrappedEcdhPrivateKey),
+    signedEcdhPublicKey: base64.encode(signedEcdhPublicKey),
+    ecdhKeyWrapperSalt: base64.encode(ecdhKeyWrapperSalt),
+  }
+}
+
+export default {
+  generateEcdhKeyData,
+  importEcdhKeyWrapperFromMaster,
+  getRawPublicKeyFromPublicKey,
+  unwrapEcdhPrivateKey,
+}

--- a/src/userbase-js/src/Crypto/ecdsa.js
+++ b/src/userbase-js/src/Crypto/ecdsa.js
@@ -1,0 +1,122 @@
+import base64 from 'base64-arraybuffer'
+import sha256 from './sha-256'
+import hkdf from './hkdf'
+import aesKw from './aes-kw'
+import aesGcm from './aes-gcm'
+import { appendBuffer } from './utils'
+
+const ECDSA_ALGORITHM_NAME = 'ECDSA'
+const KEY_IS_EXTRACTABLE = true
+const KEY_WILL_BE_USED_TO = ['sign', 'verify']
+const PUBLIC_KEY_TYPE = 'spki'
+
+const ECDSA_KEY_WRAPPER = 'ecdsa-key-wrapper'
+
+/**
+ * NIST recommendation:
+ *
+ * 128-bit security provided with 256-bit key size
+ *
+ * Pg. 55
+ * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf
+ *
+ **/
+const NAMED_CURVE = 'P-256'
+
+const ECDSA_PARAMS = {
+  name: ECDSA_ALGORITHM_NAME,
+  namedCurve: NAMED_CURVE
+}
+
+const generateKeyPair = async () => {
+  const keyPair = await window.crypto.subtle.generateKey(
+    ECDSA_PARAMS,
+    KEY_IS_EXTRACTABLE,
+    KEY_WILL_BE_USED_TO
+  )
+  return keyPair
+}
+
+const getPublicKeyStringFromPublicKey = async (publicKey) => {
+  const rawPublicKey = await window.crypto.subtle.exportKey(PUBLIC_KEY_TYPE, publicKey)
+  const publicKeyString = base64.encode(rawPublicKey)
+  return publicKeyString
+}
+
+const importEcdsaKeyWrapperFromMaster = async (masterKey, salt) => {
+  const keyWrapper = await window.crypto.subtle.deriveKey(
+    hkdf.getParams(ECDSA_KEY_WRAPPER, salt),
+    masterKey,
+    aesGcm.getEncryptionKeyParams(), // must use aes-gcm kw for ECDSA with WebCrypto
+    aesKw.KEY_IS_NOT_EXTRACTABLE,
+    aesKw.KEY_WILL_BE_USED_TO
+  )
+  return keyWrapper
+}
+
+const wrapEcdsaPrivateKey = async (ecdsaPrivateKey, ecdsaKeyWrapper) => {
+  const iv = aesGcm.generateIv()
+
+  // this result is the concatenation of Array Buffers [ciphertext, auth tag]
+  const ciphertextArrayBuffer = await window.crypto.subtle.wrapKey(
+    aesKw.KEY_TYPE,
+    ecdsaPrivateKey,
+    ecdsaKeyWrapper,
+    aesGcm.getCiphertextParams(iv)
+  )
+
+  return appendBuffer(ciphertextArrayBuffer, iv)
+}
+
+const unwrapEcdsaPrivateKey = async (wrappedEcdsaPrivateKey, ecdsaKeyWrapper) => {
+  const { ciphertextArrayBuffer, iv } = aesGcm.sliceEncryptedArrayBuffer(wrappedEcdsaPrivateKey)
+
+  const ecdsaPrivateKey = await window.crypto.subtle.unwrapKey(
+    aesKw.KEY_TYPE,
+    ciphertextArrayBuffer,
+    ecdsaKeyWrapper,
+    aesGcm.getCiphertextParams(iv),
+    ECDSA_PARAMS,
+    KEY_IS_EXTRACTABLE,
+    ['sign'] // private key can only be used to sign, not verify
+  )
+
+  return ecdsaPrivateKey
+}
+
+const generateEcdsaKeyData = async (masterKey) => {
+  // need to generate new key pair because cannot derive ECDSA key pair using HKDF in WebCrypto
+  const ecdsaKeyPair = await generateKeyPair()
+
+  // derive a key wrapper using HKDF to wrap the ECDSA private key and store it on server
+  const ecdsaKeyWrapperSalt = hkdf.generateSalt()
+  const ecdsaKeyWrapper = await importEcdsaKeyWrapperFromMaster(masterKey, ecdsaKeyWrapperSalt)
+  const wrappedEcdsaPrivateKey = await wrapEcdsaPrivateKey(ecdsaKeyPair.privateKey, ecdsaKeyWrapper)
+
+  return {
+    ecdsaPrivateKey: ecdsaKeyPair.privateKey,
+    ecdsaPublicKey: await getPublicKeyStringFromPublicKey(ecdsaKeyPair.publicKey),
+    wrappedEcdsaPrivateKey: base64.encode(wrappedEcdsaPrivateKey),
+    ecdsaKeyWrapperSalt: base64.encode(ecdsaKeyWrapperSalt),
+  }
+}
+
+const sign = async (privateKey, data) => {
+  const signature = await window.crypto.subtle.sign(
+    {
+      name: ECDSA_ALGORITHM_NAME,
+      hash: { name: sha256.HASH_ALGORITHM_NAME }
+    },
+    privateKey,
+    data
+  )
+  return signature
+}
+
+export default {
+  generateEcdsaKeyData,
+  importEcdsaKeyWrapperFromMaster,
+  getPublicKeyStringFromPublicKey,
+  unwrapEcdsaPrivateKey,
+  sign,
+}

--- a/src/userbase-js/src/Crypto/index.js
+++ b/src/userbase-js/src/Crypto/index.js
@@ -1,5 +1,8 @@
 import aesGcm from './aes-gcm'
+import aesKw from './aes-kw'
 import diffieHellman from './diffie-hellman'
+import ecdsa from './ecdsa'
+import ecdh from './ecdh'
 import sha256 from './sha-256'
 import hmac from './hmac'
 import hkdf from './hkdf'
@@ -11,7 +14,10 @@ const generateSeed = () => window.crypto.getRandomValues(new Uint8Array(SEED_BYT
 export default {
   generateSeed,
   aesGcm,
+  aesKw,
   diffieHellman,
+  ecdsa,
+  ecdh,
   sha256,
   hmac,
   hkdf,

--- a/src/userbase-js/src/api/auth.js
+++ b/src/userbase-js/src/api/auth.js
@@ -47,7 +47,7 @@ const processXhr = (xhr, resolve, reject) => {
   xhr.ontimeout = () => reject(new TimeoutError(TEN_SECONDS_MS))
 }
 
-const signUp = (username, passwordToken, publicKey, passwordSalts, keySalts, email, profile, passwordBasedBackup) => {
+const signUp = (username, passwordToken, ecKeyData, passwordSalts, keySalts, email, profile, passwordBasedBackup) => {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest()
 
@@ -56,7 +56,7 @@ const signUp = (username, passwordToken, publicKey, passwordSalts, keySalts, ema
     const data = JSON.stringify({
       username,
       passwordToken,
-      publicKey,
+      ecKeyData,
       passwordSalts,
       keySalts,
       email,

--- a/src/userbase-js/src/auth.js
+++ b/src/userbase-js/src/auth.js
@@ -168,23 +168,28 @@ const _generateKeysAndSignUp = async (username, password, seed, email, profile) 
   const masterKey = await crypto.hkdf.importHkdfKey(seed)
 
   const encryptionKeySalt = crypto.hkdf.generateSalt()
-  const dhKeySalt = crypto.hkdf.generateSalt()
   const hmacKeySalt = crypto.hkdf.generateSalt()
-
-  const dhPrivateKey = await crypto.diffieHellman.importKeyFromMaster(masterKey, dhKeySalt)
-  const publicKey = crypto.diffieHellman.getPublicKey(dhPrivateKey)
-
   const keySalts = {
     encryptionKeySalt: base64.encode(encryptionKeySalt),
-    dhKeySalt: base64.encode(dhKeySalt),
     hmacKeySalt: base64.encode(hmacKeySalt),
+  }
+
+  const ecdsaKeyData = await crypto.ecdsa.generateEcdsaKeyData(masterKey)
+  const ecdhKeyData = await crypto.ecdh.generateEcdhKeyData(masterKey, ecdsaKeyData.ecdsaPrivateKey)
+
+  delete ecdsaKeyData.ecdsaPrivateKey
+  delete ecdhKeyData.ecdhPrivateKey
+
+  const ecKeyData = {
+    ecdsaKeyData,
+    ecdhKeyData,
   }
 
   try {
     const session = await api.auth.signUp(
       username,
       passwordToken,
-      publicKey,
+      ecKeyData,
       passwordSalts,
       keySalts,
       email,
@@ -732,6 +737,8 @@ const forgotPassword = async (params) => {
           const message = JSON.parse(e.data)
 
           switch (message.route) {
+
+            // users created with userbase-js < v2.0.0 that have not signed in yet will need to prove access to DH key by decrypting token
             case 'ReceiveEncryptedToken': {
               // if client decrypts encrypted token successfully, proves to server it has the user's key
               const encryptedForgotPasswordToken = new Uint8Array(message.encryptedForgotPasswordToken.data)
@@ -750,6 +757,34 @@ const forgotPassword = async (params) => {
               forgotPasswordWs.send(JSON.stringify({
                 action: 'ForgotPassword',
                 params: { forgotPasswordToken }
+              }))
+
+              break
+            }
+
+            // users signed in with userbase-js >= v2.0.0 will need to prove access to ECDSA key by signing token
+            case 'ReceiveToken': {
+              const {
+                ecdsaKeyWrapperSalt,
+                wrappedEcdsaPrivateKey,
+                forgotPasswordToken,
+              } = message
+
+              const ecdsaKeyWrapper = await crypto.ecdsa.importEcdsaKeyWrapperFromMaster(masterKey, base64.decode(ecdsaKeyWrapperSalt))
+
+              let ecdsaPrivateKey
+              try {
+                // if it fails to unwrap, it's almost certainly because key is incorrect
+                ecdsaPrivateKey = await crypto.ecdsa.unwrapEcdsaPrivateKey(base64.decode(wrappedEcdsaPrivateKey), ecdsaKeyWrapper)
+              } catch {
+                throw new errors.KeyNotFound(keyNotFoundMessage)
+              }
+
+              const signedForgotPasswordToken = base64.encode(await crypto.ecdsa.sign(ecdsaPrivateKey, base64.decode(forgotPasswordToken)))
+
+              forgotPasswordWs.send(JSON.stringify({
+                action: 'ForgotPassword',
+                params: { signedForgotPasswordToken }
               }))
 
               break

--- a/src/userbase-server/crypto/ecdsa.js
+++ b/src/userbase-server/crypto/ecdsa.js
@@ -1,0 +1,22 @@
+import crypto from 'crypto'
+
+const verify = (data, publicKey, signature) => {
+  const verifier = crypto.createVerify('SHA256')
+
+  verifier.update(data).end()
+
+  const verifyParams = {
+    key: Buffer.from(publicKey, 'base64'),
+
+    // these are specific to WebCrypto
+    format: 'der',
+    type: 'spki',
+    dsaEncoding: 'ieee-p1363'
+  }
+
+  return verifier.verify(verifyParams, signature, 'base64')
+}
+
+export default {
+  verify,
+}

--- a/src/userbase-server/crypto/index.js
+++ b/src/userbase-server/crypto/index.js
@@ -1,4 +1,5 @@
 import aesGcm from './aesGcm'
+import ecdsa from './ecdsa'
 import diffieHellman from './diffieHellman'
 import randomBytes from './randomBytes'
 import sha256 from './sha256'
@@ -8,6 +9,7 @@ import hkdf from './hkdf'
 
 export default {
   aesGcm,
+  ecdsa,
   diffieHellman,
   randomBytes,
   sha256,

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -67,7 +67,7 @@ const createSession = async function (userId, appId) {
 }
 
 const _buildSignUpParams = (username, passwordToken, appId, userId,
-  publicKey, passwordSalts, keySalts, email, profile, passwordBasedBackup) => {
+  publicKeyData, passwordSalts, keySalts, email, profile, passwordBasedBackup) => {
 
   const {
     passwordSalt,
@@ -76,8 +76,7 @@ const _buildSignUpParams = (username, passwordToken, appId, userId,
 
   const {
     encryptionKeySalt,
-    dhKeySalt,
-    hmacKeySalt
+    hmacKeySalt,
   } = keySalts
 
   const { passwordBasedEncryptionKeySalt, passwordEncryptedSeed } = passwordBasedBackup
@@ -89,14 +88,37 @@ const _buildSignUpParams = (username, passwordToken, appId, userId,
     'password-token-salt': passwordTokenSalt,
     'app-id': appId,
     'user-id': userId,
-    'public-key': publicKey,
     'encryption-key-salt': encryptionKeySalt,
-    'diffie-hellman-key-salt': dhKeySalt,
     'hmac-key-salt': hmacKeySalt,
     'seed-not-saved-yet': true,
     'creation-date': new Date().toISOString(),
     'password-based-encryption-key-salt': passwordBasedEncryptionKeySalt,
-    'password-encrypted-seed': passwordEncryptedSeed
+    'password-encrypted-seed': passwordEncryptedSeed,
+  }
+
+  const {
+    ecKeyData,    // userbase-js >= v2.0.0
+    dhPublicKey,  // userbase-js <  v2.0.0
+  } = publicKeyData
+
+  if (ecKeyData) {
+    const { ecdsaKeyData, ecdhKeyData } = ecKeyData
+    const { ecdsaPublicKey, wrappedEcdsaPrivateKey, ecdsaKeyWrapperSalt } = ecdsaKeyData
+    const { ecdhPublicKey, wrappedEcdhPrivateKey, ecdhKeyWrapperSalt, signedEcdhPublicKey } = ecdhKeyData
+
+    user['ecdsa-public-key'] = ecdsaPublicKey
+    user['ecdh-public-key'] = ecdhPublicKey
+
+    user['wrapped-ecdsa-private-key'] = wrappedEcdsaPrivateKey
+    user['wrapped-ecdh-private-key'] = wrappedEcdhPrivateKey
+
+    user['ecdsa-key-wrapper-salt'] = ecdsaKeyWrapperSalt
+    user['ecdh-key-wrapper-salt'] = ecdhKeyWrapperSalt
+
+    user['signed-ecdh-public-key'] = signedEcdhPublicKey
+  } else if (dhPublicKey) {
+    user['public-key'] = dhPublicKey
+    user['diffie-hellman-key-salt'] = keySalts.dhKeySalt
   }
 
   if (email) user.email = email.toLowerCase()
@@ -274,10 +296,39 @@ const _validateUsernameInput = (username) => {
 }
 exports._validateUsernameInput = _validateUsernameInput
 
-const _validateSignUpInput = (appId, username, passwordToken, publicKey, passwordSalts, keySalts, passwordBasedBackup, email, profile) => {
+const _verifyEcdhPublicKey = (ecdhPublicKey, ecdsaPublicKey, signedEcdhPublicKey) => {
+  if (!crypto.ecdsa.verify(Buffer.from(ecdhPublicKey, 'base64'), ecdsaPublicKey, signedEcdhPublicKey)) {
+    throw 'Failed to verify signed ECDH public key'
+  }
+}
+
+const _validateSignUpInput = (appId, username, passwordToken, publicKeyData, passwordSalts, keySalts, passwordBasedBackup, email, profile) => {
   try {
-    if (!appId || !username || !passwordToken || !publicKey || !passwordSalts || !keySalts || !passwordBasedBackup) {
+    const {
+      ecKeyData,    // userbase-js >= v2.0.0
+      dhPublicKey,  // userbase-js <  v2.0.0
+    } = publicKeyData
+
+    if (!appId || !username || !passwordToken || !passwordSalts || !keySalts || !passwordBasedBackup ||
+      (!ecKeyData && !dhPublicKey)) {
       throw 'Missing required items'
+    }
+
+    if (ecKeyData) {
+      const { ecdsaKeyData, ecdhKeyData } = ecKeyData
+      if (!ecdsaKeyData || !ecdhKeyData) throw 'Missing required items'
+
+      const { ecdsaPublicKey, wrappedEcdsaPrivateKey } = ecdsaKeyData
+      if (!ecdsaPublicKey || !wrappedEcdsaPrivateKey) throw 'Missing required items'
+
+      const { ecdhPublicKey, wrappedEcdhPrivateKey, signedEcdhPublicKey } = ecdhKeyData
+      if (!ecdhPublicKey || !wrappedEcdhPrivateKey || !signedEcdhPublicKey) throw 'Missing required items'
+
+      const { ecdsaKeyWrapperSalt } = ecdsaKeyData
+      const { ecdhKeyWrapperSalt } = ecdhKeyData
+      if (!ecdsaKeyWrapperSalt || !ecdhKeyWrapperSalt) throw 'Missing required salts'
+
+      _verifyEcdhPublicKey(ecdhPublicKey, ecdsaPublicKey, signedEcdhPublicKey)
     }
 
     const {
@@ -291,7 +342,8 @@ const _validateSignUpInput = (appId, username, passwordToken, publicKey, passwor
       hmacKeySalt
     } = keySalts
 
-    if (!passwordSalt || !passwordTokenSalt || !encryptionKeySalt || !dhKeySalt || !hmacKeySalt) {
+    if (!passwordSalt || !passwordTokenSalt || !encryptionKeySalt || !hmacKeySalt ||
+      (dhPublicKey && !dhKeySalt)) {
       throw 'Missing required salts'
     }
 
@@ -342,7 +394,8 @@ exports.signUp = async function (req, res) {
   const username = req.body.username
   const passwordToken = req.body.passwordToken
 
-  const publicKey = req.body.publicKey
+  const dhPublicKey = req.body.publicKey  // userbase-js <  v2.0.0
+  const ecKeyData = req.body.ecKeyData    // userbase-js >= v2.0.0
 
   const passwordSalts = req.body.passwordSalts
   const keySalts = req.body.keySalts
@@ -356,7 +409,8 @@ exports.signUp = async function (req, res) {
     logChildObject = { appId, username, req: trimReq(req) }
     logger.child(logChildObject).info('Signing up user')
 
-    _validateSignUpInput(appId, username, passwordToken, publicKey, passwordSalts, keySalts, passwordBasedBackup, email, profile)
+    const publicKeyData = { dhPublicKey, ecKeyData }
+    _validateSignUpInput(appId, username, passwordToken, publicKeyData, passwordSalts, keySalts, passwordBasedBackup, email, profile)
 
     const userId = uuidv4()
 
@@ -388,7 +442,7 @@ exports.signUp = async function (req, res) {
     await _validateSubscription(admin['stripe-saas-subscription-status'], admin['stripe-cancel-saas-subscription-at'], appId)
 
     const params = _buildSignUpParams(username, passwordToken, appId, userId,
-      publicKey, passwordSalts, keySalts, email, profile, passwordBasedBackup)
+      publicKeyData, passwordSalts, keySalts, email, profile, passwordBasedBackup)
 
     try {
       const ddbClient = connection.ddbClient()
@@ -688,20 +742,14 @@ exports.verifyAuthToken = async function (req, res) {
   }
 }
 
-const _getValidationMessage = (publicKey) => {
-  const validationMessage = crypto.randomBytes(VALIDATION_MESSAGE_LENGTH)
-
+const _getEncryptedValidationMessage = (validationMessage, publicKey) => {
   const publicKeyArrayBuffer = Buffer.from(publicKey, 'base64')
   const sharedSecret = crypto.diffieHellman.computeSecret(publicKeyArrayBuffer)
   const sharedKey = crypto.sha256.hash(sharedSecret)
   const encryptedValidationMessage = crypto.aesGcm.encrypt(sharedKey, validationMessage)
 
-  return {
-    validationMessage,
-    encryptedValidationMessage
-  }
+  return encryptedValidationMessage
 }
-exports.getValidationMessage = _getValidationMessage
 
 const _buildStripeData = (user, app, admin) => {
   const stripeData = {}
@@ -723,7 +771,58 @@ const _buildStripeData = (user, app, admin) => {
   return stripeData
 }
 
-const userSavedSeed = async function (userId, appId, username, publicKey) {
+const _saveEcKeyData = async function (userId, appId, username, ecKeyData) {
+  const { ecdsaKeyData, ecdhKeyData } = ecKeyData
+  const { ecdsaPublicKey, wrappedEcdsaPrivateKey, ecdsaKeyWrapperSalt } = ecdsaKeyData
+  const { ecdhPublicKey, wrappedEcdhPrivateKey, ecdhKeyWrapperSalt, signedEcdhPublicKey } = ecdhKeyData
+
+  _verifyEcdhPublicKey(ecdhPublicKey, ecdsaPublicKey, signedEcdhPublicKey)
+
+  const updateUserParams = {
+    TableName: setup.usersTableName,
+    Key: {
+      'username': username,
+      'app-id': appId
+    },
+    UpdateExpression: 'REMOVE #dhPublicKey, #dhKeySalt SET ' +
+      '#ecdsaPublicKey = :ecdsaPublicKey, ' +
+      '#ecdhPublicKey = :ecdhPublicKey, ' +
+      '#wrappedEcdsaPrivateKey = :wrappedEcdsaPrivateKey, ' +
+      '#wrappedEcdhPrivateKey = :wrappedEcdhPrivateKey, ' +
+      '#ecdsaKeyWrapperSalt = :ecdsaKeyWrapperSalt, ' +
+      '#ecdhKeyWrapperSalt = :ecdhKeyWrapperSalt, ' +
+      '#signedEcdhPublicKey = :signedEcdhPublicKey'
+    ,
+    ConditionExpression: '#userId = :userId and attribute_exists(#dhPublicKey) and attribute_not_exists(#ecdsaPublicKey)',
+    ExpressionAttributeNames: {
+      '#userId': 'user-id',
+      '#dhPublicKey': 'public-key',
+      '#dhKeySalt': 'diffie-hellman-key-salt',
+      '#ecdsaPublicKey': 'ecdsa-public-key',
+      '#ecdhPublicKey': 'ecdh-public-key',
+      '#wrappedEcdsaPrivateKey': 'wrapped-ecdsa-private-key',
+      '#wrappedEcdhPrivateKey': 'wrapped-ecdh-private-key',
+      '#ecdsaKeyWrapperSalt': 'ecdsa-key-wrapper-salt',
+      '#ecdhKeyWrapperSalt': 'ecdh-key-wrapper-salt',
+      '#signedEcdhPublicKey': 'signed-ecdh-public-key'
+    },
+    ExpressionAttributeValues: {
+      ':userId': userId,
+      ':ecdsaPublicKey': ecdsaPublicKey,
+      ':ecdhPublicKey': ecdhPublicKey,
+      ':wrappedEcdsaPrivateKey': wrappedEcdsaPrivateKey,
+      ':wrappedEcdhPrivateKey': wrappedEcdhPrivateKey,
+      ':ecdsaKeyWrapperSalt': ecdsaKeyWrapperSalt,
+      ':ecdhKeyWrapperSalt': ecdhKeyWrapperSalt,
+      ':signedEcdhPublicKey': signedEcdhPublicKey
+    },
+  }
+
+  const ddbClient = connection.ddbClient()
+  await ddbClient.update(updateUserParams).promise()
+}
+
+const userSavedSeed = async function (userId, appId, username, ecdsaPublicKey, dhPublicKey) {
   const updateUserParams = {
     TableName: setup.usersTableName,
     Key: {
@@ -735,11 +834,11 @@ const userSavedSeed = async function (userId, appId, username, publicKey) {
     ExpressionAttributeNames: {
       '#seedNotSavedYet': 'seed-not-saved-yet',
       '#userId': 'user-id',
-      '#publicKey': 'public-key'
+      '#publicKey': ecdsaPublicKey ? 'ecdsa-public-key' : 'public-key'
     },
     ExpressionAttributeValues: {
       ':userId': userId,
-      ':publicKey': publicKey
+      ':publicKey': ecdsaPublicKey || dhPublicKey
     },
   }
 
@@ -747,18 +846,29 @@ const userSavedSeed = async function (userId, appId, username, publicKey) {
   await ddbClient.update(updateUserParams).promise()
 }
 
-exports.validateKey = async function (validationMessage, userProvidedValidationMessage, conn, admin, app, user) {
+const _validateKey = (user, validationMessage, userProvidedValidationMessage) => {
+  const ecdsaPublicKey = user['ecdsa-public-key']
+
+  if (ecdsaPublicKey) {
+    // user needed to digitally sign the validation message with ECDSA private key
+    return crypto.ecdsa.verify(validationMessage, ecdsaPublicKey, userProvidedValidationMessage)
+  } else {
+    // user needed to decrypt validation message with shared key
+    return validationMessage.toString('base64') === userProvidedValidationMessage
+  }
+}
+
+exports.validateKey = async function (validationMessage, userProvidedValidationMessage, conn, admin, app, user, ecKeyData) {
   const seedNotSavedYet = user['seed-not-saved-yet']
   const userId = user['user-id']
   const appId = user['app-id']
   const username = user['username']
-  const userPublicKey = user['public-key']
 
-  if (validationMessage.toString('base64') === userProvidedValidationMessage) {
+  if (_validateKey(user, validationMessage, userProvidedValidationMessage)) {
     try {
       if (seedNotSavedYet) {
         try {
-          await userSavedSeed(userId, appId, username, userPublicKey)
+          await userSavedSeed(userId, appId, username, user['ecdsa-public-key'], user['public-key'])
         } catch (e) {
           if (e.name === 'ConditionalCheckFailedException') {
             return responseBuilder.errorResponse(statusCodes['Unauthorized'], 'Invalid seed')
@@ -767,6 +877,9 @@ exports.validateKey = async function (validationMessage, userProvidedValidationM
           throw e
         }
       }
+
+      // old user created <= userbase-js v2.0.0 must be signing in to updated client for first time
+      if (ecKeyData) await _saveEcKeyData(userId, appId, username, ecKeyData)
 
       conn.validateKey()
 
@@ -1594,16 +1707,31 @@ const _precheckGenerateForgotPasswordToken = async function (appId, username) {
   return { user, app, admin }
 }
 
-exports.generateForgotPasswordToken = async function (req, appId, username) {
+exports.generateForgotPasswordToken = async function (logChildObject, appId, username) {
   try {
-    logger.child({ appId, username, req: trimReq(req) }).info('Generating forgot password token')
+    logger.child(logChildObject).info('Generating forgot password token')
 
     const { user, app, admin } = await _precheckGenerateForgotPasswordToken(appId, username)
+    logChildObject.userId = user['user-id']
+    logChildObject.adminId = admin['admin-id']
 
-    const { validationMessage, encryptedValidationMessage } = _getValidationMessage(user['public-key'])
+    let validationMessage = crypto.randomBytes(VALIDATION_MESSAGE_LENGTH)
+    let encryptedValidationMessage
+    if (user['ecdsa-public-key']) {
+      logChildObject.usingDhKey = false
+
+      // user is expected to sign this message with ECDSA private key
+      validationMessage = validationMessage.toString('base64')
+    } else {
+      const dhPublicKey = user['public-key']
+      logChildObject.usingDhKey = true
+
+      // user is expected to decrypt this message with DH private key
+      encryptedValidationMessage = _getEncryptedValidationMessage(validationMessage, dhPublicKey)
+    }
 
     logger
-      .child({ appId, username, userId: user['user-id'], statusCode: statusCodes['Success'], req: trimReq(req) })
+      .child({ ...logChildObject, statusCode: statusCodes['Success'] })
       .info('Successfully generated forgot password token')
 
     const forgotPasswordToken = validationMessage
@@ -1614,11 +1742,11 @@ exports.generateForgotPasswordToken = async function (req, appId, username) {
     const message = 'Failed to generate forgot password token.'
 
     if (e.status && e.error) {
-      logger.child({ appId, username, statusCode: e.status, err: e.error, req: trimReq(req) }).warn(message)
+      logger.child({ ...logChildObject, statusCode: e.status, err: e.error }).warn(message)
       return responseBuilder.errorResponse(e.status, e.error)
     } else {
       const statusCode = statusCodes['Internal Server Error']
-      logger.child({ appId, username, statusCode, err: e, req: trimReq(req) }).error(message)
+      logger.child({ ...logChildObject, statusCode, err: e }).error(message)
       return responseBuilder.errorResponse(statusCode, message)
     }
   }
@@ -1652,18 +1780,23 @@ const _generateTempPasswordToken = async (tempPassword, passwordSalt, passwordTo
   return tempPasswordToken
 }
 
-exports.forgotPassword = async function (req, forgotPasswordToken, userProvidedForgotPasswordToken, user, app) {
+exports.forgotPassword = async function (logChildObject, forgotPasswordToken, userProvidedForgotPasswordToken, user, app) {
   const userId = user['user-id']
   const appId = app['app-id']
 
-  let logChildObject
   try {
-    logChildObject = { userId, appId, req: trimReq(req) }
     logger.child(logChildObject).info('User forgot password')
 
-    // check if client decrypted forgot password token successfully
-    if (forgotPasswordToken.toString('base64') !== userProvidedForgotPasswordToken) {
-      throw { status: statusCodes['Unauthorized'], error: { name: 'KeyNotValid' } }
+    if (user['ecdsa-public-key']) {
+      // check if client signed forgot password token successfully
+      if (!crypto.ecdsa.verify(Buffer.from(forgotPasswordToken, 'base64'), user['ecdsa-public-key'], userProvidedForgotPasswordToken)) {
+        throw { status: statusCodes['Unauthorized'], error: { name: 'KeyNotValid' } }
+      }
+    } else {
+      // check if client decrypted forgot password token successfully
+      if (forgotPasswordToken.toString('base64') !== userProvidedForgotPasswordToken) {
+        throw { status: statusCodes['Unauthorized'], error: { name: 'KeyNotValid' } }
+      }
     }
 
     const tempPassword = crypto
@@ -2281,4 +2414,47 @@ exports.updatePaymentMethod = async function (logChildObject, app, admin, user, 
       return responseBuilder.errorResponse(statusCode, message)
     }
   }
+}
+
+exports.sendConnection = function (connectionLogObject, ws, user) {
+  const validationMessage = crypto.randomBytes(VALIDATION_MESSAGE_LENGTH)
+
+  const keySalts = {
+    encryptionKeySalt: user['encryption-key-salt'],
+    hmacKeySalt: user['hmac-key-salt'],
+  }
+
+  const webSocketMessage = {
+    route: 'Connection',
+    keySalts,
+  }
+
+  if (user['ecdsa-public-key']) {
+    connectionLogObject.usingDhKey = false
+
+    // user is expected to sign this message with ECDSA private key
+    webSocketMessage.validationMessage = validationMessage.toString('base64')
+
+    keySalts.ecdsaKeyWrapperSalt = user['ecdsa-key-wrapper-salt']
+    keySalts.ecdhKeyWrapperSalt = user['ecdh-key-wrapper-salt']
+
+    webSocketMessage.ecKeyData = {
+      wrappedEcdsaPrivateKey: user['wrapped-ecdsa-private-key'],
+      wrappedEcdhPrivateKey: user['wrapped-ecdh-private-key']
+    }
+  } else {
+    const dhPublicKey = user['public-key']
+    connectionLogObject.usingDhKey = true
+
+    // user is expected to decrypt this message with DH private key
+    const encryptedValidationMessage = _getEncryptedValidationMessage(validationMessage, dhPublicKey)
+    webSocketMessage.encryptedValidationMessage = encryptedValidationMessage
+
+    keySalts.dhKeySalt = user['diffie-hellman-key-salt']
+  }
+
+  logger.child(connectionLogObject).info('Sending Connection over WebSocket')
+  ws.send(JSON.stringify(webSocketMessage))
+
+  return validationMessage
 }


### PR DESCRIPTION
### Overview

- New users generate ECDSA & ECDH key pairs, then wrap them using key wrappers derived from their seed. The server then stores public keys, wrapped private keys, and salts (as well as the ECDH public key digitally signed by the ECDSA key).
- All future logins, the server authenticates the user by verifying the user can digitally sign a random message using the private key associated with the stored ECDSA public key.
- Old clients will still work normally using DH.
- Old users signing in with a new client will automatically generate ECDSA + ECDH key pairs. The server stores them and deletes DH key, and will use the ECDSA public key authentication process described above going forward.