### PR TITLE
userbase-js init now returns immediately if user's session has expired

### DIFF
--- a/src/userbase-js/CHANGELOG.md
+++ b/src/userbase-js/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.1] - 2020-05-15
+## Changed
+- init() now returns immediately if the user's session has expired rather than make a request to the Userbase server to find out it has expired.
+
 ## [1.4.0] - 2020-05-04
 ## Added
 - purchaseSubscription(), cancelSubscription(), resumeSubscription(), and updatePaymentMethod() functions to enable developers to accept subscription payments from their users.

--- a/src/userbase-js/package-lock.json
+++ b/src/userbase-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "userbase-js",
-  "version": "1.2.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/userbase-js/package.json
+++ b/src/userbase-js/package.json
@@ -33,7 +33,7 @@
     "type": "git",
     "url": "git+https://github.com/encrypted-dev/userbase.git"
   },
-  "version": "1.3.0",
+  "version": "1.4.1",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "npm run build:esm && npm run build:cjs && npm run build:umd",

--- a/src/userbase-js/src/localData.js
+++ b/src/userbase-js/src/localData.js
@@ -14,8 +14,8 @@ const tryCatchWrapper = (func) => (...args) => {
 
 const _getSeedName = (appId, username) => `userbaseSeed.${appId}.${username}`
 
-const setCurrentSession = tryCatchWrapper((rememberMe, username, signedIn, sessionId, creationDate) => {
-  const session = { username, signedIn, sessionId, creationDate }
+const setCurrentSession = tryCatchWrapper((rememberMe, username, signedIn, sessionId, creationDate, expirationDate) => {
+  const session = { username, signedIn, sessionId, creationDate, expirationDate }
   const sessionString = JSON.stringify(session)
 
   if (rememberMe === 'local') {
@@ -80,9 +80,9 @@ const getSeedString = tryCatchWrapper((appId, username) => {
   return sessionStorage.getItem(seedName) || localStorage.getItem(seedName)
 })
 
-const signInSession = (rememberMe, username, sessionId, creationDate) => {
+const signInSession = (rememberMe, username, sessionId, creationDate, expirationDate) => {
   const signedIn = true
-  setCurrentSession(rememberMe, username, signedIn, sessionId, creationDate)
+  setCurrentSession(rememberMe, username, signedIn, sessionId, creationDate, expirationDate)
 }
 
 const signOutSession = (rememberMe, username) => {

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -25,11 +25,13 @@ const createSession = async function (adminId) {
     .randomBytes(ACCEPTABLE_RANDOM_BYTES_FOR_SAFE_SESSION_ID)
     .toString('hex')
 
+  const expirationDate = new Date(Date.now() + MS_IN_A_DAY).toISOString()
+
   const session = {
     'session-id': sessionId,
     'admin-id': adminId,
     'creation-date': new Date().toISOString(),
-    ttl: getTtl(SECONDS_IN_A_DAY),
+    ttl: getTtl(expirationDate),
   }
 
   const params = {

--- a/src/userbase-server/utils.js
+++ b/src/userbase-server/utils.js
@@ -62,7 +62,7 @@ export const trimReq = (req) => ({ id: req.id, url: req.url })
 
 export const truncateSessionId = (sessionId) => typeof sessionId === 'string' && sessionId.substring(0, 8) // limit sensitive logging
 
-export const getTtl = (secondsToLive) => Math.floor(Date.now() / 1000) + secondsToLive
+export const getTtl = (expirationDate) => Math.floor(new Date(expirationDate).getTime() / 1000)
 
 // matches stringToArrayBuffer from userbase-js/Crypto/utils
 // https://developers.google.com/web/updates/2012/06/How-to-convert-ArrayBuffer-to-and-from-String


### PR DESCRIPTION
### Overview

When a user signs in to Userbase, they receive a session that expires after 24 hours, allowing the user to automatically sign back in to Userbase on subsequent visits to an app for 24 hours when **rememberMe** is set to `'session`' or `'local'`. Userbase devs use [`userbase.init()`](https://userbase.com/docs/sdk/init/) to automatically sign users back in. If the user attempts to call `userbase.init()` *after* the session has expired, the user will not be automatically signed in and the response to init() will instead include the user's `lastUsedUsername`.

Before this PR, userbase-js would make a request to the server to find out the user's session has expired.

Now, we store the session expiration date locally, allowing init() to return immediately without needing to make a request to the server if the user's session has expired.

[Credit to Eunjae](https://twitter.com/eunjae_lee/status/1261054012788482048) for pointing this out :)