### PR TITLE
Update user handler

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "testFiles": "**/*.spec.js",
-  "defaultCommandTimeout": 60000,
+  "defaultCommandTimeout": 1200000,
   "requestTimeout": 6000,
   "chromeWebSecurity": false,
   "projectId": "uokg4h",

--- a/cypress/integration/Admin API/user.spec.js
+++ b/cypress/integration/Admin API/user.spec.js
@@ -83,6 +83,7 @@ const beforeEachHook = function () {
           that.currentTest.username = randomUser
           that.currentTest.password = password
           that.currentTest.userId = user.userId
+          that.currentTest.user = user
         })
       })
     }
@@ -405,6 +406,58 @@ describe('UpdateUser', function () {
                 })
               })
 
+            })
+        })
+      })
+    })
+
+    it('Userbase updateUserHandler called when UpdateUser sets protected profile', function () {
+      const {
+        userId,
+        userbase,
+        accessToken,
+        appId,
+        user,
+      } = this.test
+
+      const protectedProfile = { 'Hello': 'World!' }
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal({ ...user, protectedProfile })
+        success = true
+      }
+
+      function setUpdateUserHandler() {
+        return new Cypress.Promise(function (resolve, reject) {
+          userbase.init({ appId, updateUserHandler })
+            .then(() => resolve())
+            .catch((e) => reject(e))
+        })
+      }
+
+      cy.wrap(null).then(() => {
+        return setUpdateUserHandler().then(function () {
+          cy
+            .request({
+              method: 'POST',
+              url: USER_ENDPOINT + userId,
+              auth: {
+                bearer: accessToken
+              },
+              body: {
+                protectedProfile
+              }
+            })
+            .then(function (response) {
+              expect(response.status, 'status').to.eq(200)
+              expect(response.body, 'no body').to.be.undefined
+
+              cy.wait(3000)
+              expect(success, 'success').to.be.true
+
+              cy.request({ method: 'POST', url: Cypress.env('endpoint') + '/admin/delete-admin' })
             })
         })
       })
@@ -740,6 +793,150 @@ describe('UpdateUser', function () {
             })
         })
       })
+    })
+
+    it('Userbase updateUserHandler called when UpdateUser sets protected profile to false', function () {
+      const {
+        userId,
+        userbase,
+        accessToken,
+        appId,
+        user,
+      } = this.test
+
+      const protectedProfile = { 'Hello': 'World!' }
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal(user)
+        expect(updatedUser, 'no protected profile key').to.not.have.key('protectedProfile')
+        success = true
+      }
+
+      function setUpdateUserHandler() {
+        return new Cypress.Promise(function (resolve, reject) {
+          userbase.init({ appId, updateUserHandler })
+            .then(() => resolve())
+            .catch((e) => reject(e))
+        })
+      }
+
+      cy
+        .request({
+          method: 'POST',
+          url: USER_ENDPOINT + userId,
+          auth: {
+            bearer: accessToken
+          },
+          body: {
+            protectedProfile
+          }
+        })
+        .then(function (response) {
+          expect(response.status, 'status').to.eq(200)
+          expect(response.body, 'no body').to.be.undefined
+
+          cy.wrap(null).then(() => {
+            return setUpdateUserHandler().then(function () {
+              cy
+                .request({
+                  method: 'POST',
+                  url: USER_ENDPOINT + userId,
+                  auth: {
+                    bearer: accessToken
+                  },
+                  body: {
+                    protectedProfile: false
+                  }
+                })
+                .then(function (response) {
+                  expect(response.status, 'status').to.eq(200)
+                  expect(response.body, 'no body').to.be.undefined
+
+                  cy.wait(3000)
+                  expect(success, 'success').to.be.true
+
+                  cy.request({ method: 'POST', url: Cypress.env('endpoint') + '/admin/delete-admin' })
+                })
+            })
+          })
+
+
+        })
+
+    })
+
+    it('Userbase updateUserHandler called when UpdateUser sets protected profile to null', function () {
+      const {
+        userId,
+        userbase,
+        accessToken,
+        appId,
+        user,
+      } = this.test
+
+      const protectedProfile = { 'Hello': 'World!' }
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal(user)
+        expect(updatedUser, 'no protected profile key').to.not.have.key('protectedProfile')
+        success = true
+      }
+
+      function setUpdateUserHandler() {
+        return new Cypress.Promise(function (resolve, reject) {
+          userbase.init({ appId, updateUserHandler })
+            .then(() => resolve())
+            .catch((e) => reject(e))
+        })
+      }
+
+      cy
+        .request({
+          method: 'POST',
+          url: USER_ENDPOINT + userId,
+          auth: {
+            bearer: accessToken
+          },
+          body: {
+            protectedProfile
+          }
+        })
+        .then(function (response) {
+          expect(response.status, 'status').to.eq(200)
+          expect(response.body, 'no body').to.be.undefined
+
+          cy.wrap(null).then(() => {
+            return setUpdateUserHandler().then(function () {
+              cy
+                .request({
+                  method: 'POST',
+                  url: USER_ENDPOINT + userId,
+                  auth: {
+                    bearer: accessToken
+                  },
+                  body: {
+                    protectedProfile: null
+                  }
+                })
+                .then(function (response) {
+                  expect(response.status, 'status').to.eq(200)
+                  expect(response.body, 'no body').to.be.undefined
+
+                  cy.wait(3000)
+                  expect(success, 'success').to.be.true
+
+                  cy.request({ method: 'POST', url: Cypress.env('endpoint') + '/admin/delete-admin' })
+                })
+            })
+          })
+
+
+        })
+
     })
 
   })

--- a/cypress/integration/updateUser.spec.js
+++ b/cypress/integration/updateUser.spec.js
@@ -577,7 +577,7 @@ describe('Update User Tests', function () {
         }
 
         // cooldown for rate limiter
-        await wait(1000)
+        await wait(1500)
       }
 
       try {

--- a/cypress/integration/updateUser.spec.js
+++ b/cypress/integration/updateUser.spec.js
@@ -577,7 +577,7 @@ describe('Update User Tests', function () {
         }
 
         // cooldown for rate limiter
-        await wait(1500)
+        await wait(2000)
       }
 
       try {

--- a/cypress/integration/updateUser.spec.js
+++ b/cypress/integration/updateUser.spec.js
@@ -1,731 +1,686 @@
-/// <reference types="Cypress" />
+import { getRandomString, wait } from '../support/utils'
 
-describe('Update User Testing', function () {
-  let info = {}
-  let randomInfo, profile, email
-  const newUsername = 'testuser6'
-  const newPassword = 'validpassword'
+const beforeEachHook = function (signUp = true) {
+  cy.visit('./cypress/integration/index.html').then(async function (win) {
+    expect(win).to.have.property('userbase')
+    const userbase = win.userbase
+    this.currentTest.userbase = userbase
 
-  beforeEach(() => {
-    info = Cypress.env()
-    cy.visit('./cypress/integration/index.html').then((win) => {
-      expect(win).to.have.property('userbase')
-      cy.clearLocalStorage()
-    })
+    const { appId, endpoint } = Cypress.env()
+    win._userbaseEndpoint = endpoint
+    userbase.init({ appId })
+    this.currentTest.appId = appId
 
-    profile = {
-      a: 'a',
-      b: 'b',
-      c: 'c',
+    if (signUp) {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      const user = await userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      this.currentTest.user = user
+      this.currentTest.password = password
     }
-
-    email = 'legit.email@example.com'
-
-    cy.getRandomInfoWithParams(email, profile, 'local').then((loginInfo) => {
-      randomInfo = loginInfo
-    })
   })
-
-  after(() => {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signIn({ username: newUsername, password: newPassword }).then(() => {
-        return userbase.deleteUser().then(() => {
-          console.log('Cleaning up updated user')
-          window.localStorage.clear()
-        })
-      }).catch(() => { })
-    })
-  })
-
-  it('Update user\'s e-mail, password and profile', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        email = 'another.legit.email@example.com'
-        profile = {
-          b: 'x',
-          c: 'c',
-          d: 'y',
-        }
-
-        const updateInfo = {
-          username: newUsername,
-          currentPassword: randomInfo.password,
-          newPassword,
-          email,
-          profile,
-        }
-
-        const newLoginInfo = {
-          ...randomInfo,
-          password: newPassword,
-          username: newUsername,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          return userbase.signOut().then(() => {
-            return userbase.signIn(newLoginInfo).then(user => {
-              expect(user.username, 'user.username').to.exists
-              expect(user.username, 'user.username to be the one signed up').to.equal(newUsername)
-              expect(user.email, 'user.email should be the new one').to.equal(email)
-              expect(user.profile, 'user.profile should be the new one').to.deep.equal(profile)
-
-              return userbase.deleteUser().then(() => {})
-            })
-          })
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ParamsMustBeObject', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const newPassword = 'validpassword'
-        email = 'another.legit.email@example.com'
-        profile = {
-          b: 'x',
-          c: 'c',
-          d: 'y',
-        }
-
-        return userbase.updateUser(user.username, randomInfo.password, newPassword, email, profile).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ParamsMustBeObject')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ParamsMissing', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        return userbase.updateUser({}).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ParamsMissing')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, UsernameAlreadyExists', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-      let secondUserRandomInfo
-
-      cy.getRandomInfoWithParams(null, null, 'local').then((loginInfo) => {
-        secondUserRandomInfo = loginInfo
-
-        return userbase.signUp(secondUserRandomInfo).then((secondUser) => {
-          cy.log(secondUser)
-          console.log(secondUser)
-
-          return userbase.signOut(() => {
-
-            return userbase.signUp(randomInfo).then((user) => {
-              cy.log(user)
-              console.log(user)
-
-              const updateInfo = {
-                username: secondUser.username,
-              }
-
-              return userbase.updateUser(updateInfo).then(() => {
-                expect(true, 'updateUser should not be successful').to.be.false
-              }).catch(error => {
-                expect(error).to.be.a('Error')
-                expect(error.name).to.be.equal('UsernameAlreadyExists')
-              }).finally(() => {
-                return userbase.deleteUser().then(() => {
-                  return userbase.signIn(secondUserRandomInfo).then(() => {
-                    return userbase.deleteUser().then(() => {})
-                  })
-                })
-              })
-            })
-          })
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, UsernameMustBeString', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          username: 0,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('UsernameMustBeString')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, UsernameCannotBeBlank', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          username: '',
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('UsernameCannotBeBlank')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, UsernameTooLong', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          username: 'a'.repeat(101),
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('UsernameTooLong')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, CurrentPasswordMissing', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          newPassword,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('CurrentPasswordMissing')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, CurrentPasswordIncorrect', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          currentPassword: 'incorrectpassword',
-          newPassword,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('CurrentPasswordIncorrect')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, PasswordAttemptLimitExceeded', function () {
-
-  })
-
-  it('Update user\'s info, PasswordMustBeString', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          currentPassword: randomInfo.password,
-          newPassword: 0,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('PasswordMustBeString')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, PasswordCannotBeBlank', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          currentPassword: randomInfo.password,
-          newPassword: '',
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('PasswordCannotBeBlank')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, PasswordTooShort', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          currentPassword: randomInfo.password,
-          newPassword: 'short',
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('PasswordTooShort')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, PasswordTooLong', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        let longPassword = ''
-        for (let i = 0; i <= 1000; i++) longPassword += Math.floor(Math.random() * 10)
-
-        const updateInfo = {
-          currentPassword: randomInfo.password,
-          newPassword: longPassword,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('PasswordTooLong')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, EmailNotValid', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          email: 'invalid@email',
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('EmailNotValid')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileMustBeObject', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          profile: 'not an object',
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileMustBeObject')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileCannotBeEmpty', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const updateInfo = {
-          profile: {},
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileCannotBeEmpty')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileHasTooManyKeys', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const profileWithTooManyKeys = {}
-        for (let i = 0; i <= 1001; i++) profileWithTooManyKeys[i] = 'a'
-
-        const updateInfo = {
-          profile: profileWithTooManyKeys,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileHasTooManyKeys')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileKeyMustBeString', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const o = {}
-        const profileWithObjectAsKey = {}
-        profileWithObjectAsKey[o] = 'a'
-
-        const updateInfo = {
-          profile: profileWithObjectAsKey,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileKeyMustBeString')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileKeyTooLong', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const keyTooLong = 'a'.repeat(21)
-
-        const profileWithKeyTooLong = {}
-        profileWithKeyTooLong[keyTooLong] = 'a'
-
-        const updateInfo = {
-          profile: profileWithKeyTooLong,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileKeyTooLong')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileValueMustBeString', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const profileWithNonStringValues = {
-          a: 0
-        }
-
-        const updateInfo = {
-          profile: profileWithNonStringValues,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileValueMustBeString')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileValueTooLong', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        let valueTooLong = ''
-        for (let i = 0; i <= 1001; i++) valueTooLong += 'a'
-
-        const profileWithValueTooLong = {
-          valueTooLong
-        }
-
-        const updateInfo = {
-          profile: profileWithValueTooLong,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileValueTooLong')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, ProfileValueCannotBeBlank', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      return userbase.signUp(randomInfo).then((user) => {
-        cy.log(user)
-        console.log(user)
-
-        const profileWithBlankValue = {
-          a: ''
-        }
-
-        const updateInfo = {
-          profile: profileWithBlankValue,
-        }
-
-        return userbase.updateUser(updateInfo).then(() => {
-          expect(true, 'updateUser should not be successful').to.be.false
-        }).catch(error => {
-          expect(error).to.be.a('Error')
-          expect(error.name).to.be.equal('ProfileValueCannotBeBlank')
-        }).finally(() => {
-          return userbase.deleteUser().then(() => {})
-        })
-      })
-    })
-  })
-
-  it('Update user\'s info, UserNotSignedIn', function () {
-    cy.window().then((window) => {
-      const { userbase } = window
-      window._userbaseEndpoint = info.endpoint
-      userbase.init({ appId: info.appId })
-
-      const updateInfo = {
-        profile,
+}
+
+describe('Update User Tests', function () {
+
+  describe('Success Tests', function () {
+    beforeEach(function () { beforeEachHook() })
+
+    it('Update username', async function () {
+      const user = this.test.user
+      const startingUsername = user.username
+      const updatedUsername = 'test-user-' + getRandomString()
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser.username, 'updated username').to.not.equal(startingUsername)
+        expect(updatedUser, 'user object').to.deep.equal({ ...user, username: updatedUsername })
+        success = true
       }
 
-      return userbase.updateUser(updateInfo).then(() => {
-        expect(true, 'updateUser should not be successful').to.be.false
-      }).catch(error => {
-        expect(error).to.be.a('Error')
-        expect(error.name).to.be.equal('UserNotSignedIn')
-      })
+      // relies on idempotent call to init
+      await this.test.userbase.init({ appId: this.test.appId, updateUserHandler })
+      await this.test.userbase.updateUser({ username: updatedUsername })
+
+      expect(success, 'success').to.be.true
+
+      // clean up
+      await this.test.userbase.deleteUser()
     })
+
+    it('Update profile', async function () {
+      const user = this.test.user
+      const profile = { hello: 'world!' }
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal({ ...user, profile })
+        success = true
+      }
+
+      // relies on idempotent call to init
+      await this.test.userbase.init({ appId: this.test.appId, updateUserHandler })
+      await this.test.userbase.updateUser({ profile })
+
+      expect(success, 'success').to.be.true
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Update email', async function () {
+      const user = this.test.user
+      const email = 'test@email.com'
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal({ ...user, email })
+        success = true
+      }
+
+      // relies on idempotent call to init
+      await this.test.userbase.init({ appId: this.test.appId, updateUserHandler })
+      await this.test.userbase.updateUser({ email })
+
+      expect(success, 'success').to.be.true
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Update password', async function () {
+      const user = this.test.user
+
+      const currentPassword = this.test.password
+      const newPassword = getRandomString()
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal({ ...user, passwordChanged: true })
+        success = true
+      }
+
+      // relies on idempotent call to init
+      await this.test.userbase.init({ appId: this.test.appId, updateUserHandler })
+      await this.test.userbase.updateUser({ currentPassword, newPassword })
+
+      expect(success, 'success').to.be.true
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Sign back in after updating password', async function () {
+      const username = this.test.user.username
+
+      const currentPassword = this.test.password
+      const newPassword = getRandomString()
+
+      await this.test.userbase.updateUser({ currentPassword, newPassword })
+      await this.test.userbase.signOut()
+
+      // signing in with old password should fail
+      try {
+        await this.test.userbase.signIn({ username, password: currentPassword, rememberMe: 'none' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.status, 'error status').to.equal(401)
+        expect(e.name, 'error name').to.equal('UsernameOrPasswordMismatch')
+        expect(e.message, 'error message').to.equal('Username or password mismatch.')
+      }
+
+      // signing in with new password should succeed
+      await this.test.userbase.signIn({ username, password: newPassword, rememberMe: 'none' })
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Update username + profile + email + password', async function () {
+      const user = this.test.user
+
+      const username = 'test-user-' + getRandomString()
+      const profile = { hello: 'world!' }
+      const email = 'test@email.com'
+
+      const currentPassword = this.test.password
+      const newPassword = getRandomString()
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal({ ...user, username, profile, email, passwordChanged: true })
+        success = true
+      }
+
+      // relies on idempotent call to init
+      await this.test.userbase.init({ appId: this.test.appId, updateUserHandler })
+      await this.test.userbase.updateUser({ username, profile, email, currentPassword, newPassword })
+
+      expect(success, 'success').to.be.true
+
+      await this.test.userbase.signOut()
+
+      // signing in with old password should fail
+      try {
+        await this.test.userbase.signIn({ username, password: currentPassword, rememberMe: 'none' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.status, 'error status').to.equal(401)
+        expect(e.name, 'error name').to.equal('UsernameOrPasswordMismatch')
+        expect(e.message, 'error message').to.equal('Username or password mismatch.')
+      }
+
+      // signing in with new password should succeed
+      await this.test.userbase.signIn({ username, password: newPassword, rememberMe: 'none' })
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Remove profile', async function () {
+      const user = this.test.user
+
+      const profile = { hello: 'world!' }
+      await this.test.userbase.updateUser({ profile })
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal(user)
+        expect(updatedUser, 'no profile').to.not.have.key('profile')
+        success = true
+      }
+
+      // relies on idempotent call to init
+      await this.test.userbase.init({ appId: this.test.appId, updateUserHandler })
+      await this.test.userbase.updateUser({ profile: null })
+
+      expect(success, 'success').to.be.true
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Remove email', async function () {
+      const user = this.test.user
+
+      const email = 'example@email.com'
+      await this.test.userbase.updateUser({ email })
+
+      let success
+      const updateUserHandler = function (updatedUserResult) {
+        const updatedUser = updatedUserResult.user
+        expect(updatedUser, 'user object').to.deep.equal(user)
+        expect(updatedUser, 'no email').to.not.have.key('email')
+        success = true
+      }
+
+      // relies on idempotent call to init
+      await this.test.userbase.init({ appId: this.test.appId, updateUserHandler })
+      await this.test.userbase.updateUser({ email: null })
+
+      expect(success, 'success').to.be.true
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
   })
 
-  it('Update user\'s info, AppIdNotSet', function () {
+  describe('Failure Tests', function () {
+    beforeEach(function () { beforeEachHook(false) })
+
+    it('Update user handler must be function', async function () {
+      try {
+        await this.test.userbase.init({ appId: this.test.appId, updateUserHandler: 1 })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('UpdateUserHandlerMustBeFunction')
+        expect(e.message, 'error message').to.equal('Update user handler must be a function.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Missing params object', async function () {
+      try {
+        await this.test.userbase.updateUser()
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ParamsMustBeObject')
+        expect(e.message, 'error message').to.equal('Parameters passed to function must be placed inside an object.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Incorrect params type', async function () {
+      try {
+        await this.test.userbase.updateUser(false)
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ParamsMustBeObject')
+        expect(e.message, 'error message').to.equal('Parameters passed to function must be placed inside an object.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Params missing', async function () {
+      try {
+        await this.test.userbase.updateUser({})
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ParamsMissing')
+        expect(e.message, 'error message').to.equal('Parameters expected are missing.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Blank username', async function () {
+      try {
+        await this.test.userbase.updateUser({ username: '' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('UsernameCannotBeBlank')
+        expect(e.message, 'error message').to.equal('Username cannot be blank.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Username must be string', async function () {
+      try {
+        await this.test.userbase.updateUser({ username: false })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('UsernameMustBeString')
+        expect(e.message, 'error message').to.equal('Username must be a string.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Username too long', async function () {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      const username = 'a'.repeat(101)
+
+      try {
+        await this.test.userbase.updateUser({ username })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('UsernameTooLong')
+        expect(e.message, 'error message').to.equal('Username too long. Must be a max of 100 characters.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Username already exists', async function () {
+      const randomUser1 = 'test-user-' + getRandomString()
+      const randomUser2 = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser1,
+        password,
+        rememberMe
+      })
+      await this.test.userbase.signOut()
+
+      await this.test.userbase.signUp({
+        username: randomUser2,
+        password,
+        rememberMe
+      })
+
+      try {
+        await this.test.userbase.updateUser({ username: randomUser1 })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('UsernameAlreadyExists')
+        expect(e.message, 'error message').to.equal('Username already exists.')
+        expect(e.status, 'error status').to.equal(409)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+      await this.test.userbase.signIn({
+        username: randomUser1,
+        password,
+        rememberMe
+      })
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Profile must be object', async function () {
+      try {
+        await this.test.userbase.updateUser({ profile: 123 })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ProfileMustBeObject')
+        expect(e.message, 'error message').to.equal('Profile must be a flat JSON object.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Profile empty', async function () {
+      try {
+        await this.test.userbase.updateUser({ profile: {} })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ProfileCannotBeEmpty')
+        expect(e.message, 'error message').to.equal('Profile cannot be empty.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Profile has too many keys', async function () {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      const profile = {}
+      const MAX_KEYS = 100
+      for (let i = 0; i <= MAX_KEYS; i++) {
+        profile[i] = i.toString()
+      }
+
+      try {
+        await this.test.userbase.updateUser({ profile })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ProfileHasTooManyKeys')
+        expect(e.message, 'error message').to.equal(`Profile has too many keys. Must have a max of ${MAX_KEYS} keys.`)
+        expect(e.status, 'error status').to.equal(400)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Profile key too long', async function () {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      const key = 'a'.repeat(21)
+
+      try {
+        await this.test.userbase.updateUser({ profile: { [key]: 'hello' } })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ProfileKeyTooLong')
+        expect(e.message, 'error message').to.equal('Profile key too long. Must be a max of 20 characters.')
+        expect(e.status, 'error status').to.equal(400)
+        expect(e.key, 'error key').to.equal(key)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Profile value must be string', async function () {
+      const key = 'nest'
+      const value = {}
+
+      try {
+        await this.test.userbase.updateUser({ profile: { [key]: value } })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ProfileValueMustBeString')
+        expect(e.message, 'error message').to.equal('Profile value must be a string.')
+        expect(e.status, 'error status').to.equal(400)
+        expect(e.key, 'error key').to.equal(key)
+        expect(e.value, 'error value').to.equal(value)
+      }
+    })
+
+    it('Profile value too long', async function () {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      const key = 'nest'
+      const value = 'a'.repeat(1001)
+
+      try {
+        await this.test.userbase.updateUser({ profile: { [key]: value } })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('ProfileValueTooLong')
+        expect(e.message, 'error message').to.equal('Profile value too long. Must be a max of 1000 characters.')
+        expect(e.status, 'error status').to.equal(400)
+        expect(e.key, 'error key').to.equal(key)
+        expect(e.value, 'error value').to.equal(value)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Email not valid', async function () {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      try {
+        await this.test.userbase.updateUser({ email: 'd' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('EmailNotValid')
+        expect(e.message, 'error message').to.equal('Email not valid.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Current password missing', async function () {
+      try {
+        await this.test.userbase.updateUser({ newPassword: 'new-pass' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('CurrentPasswordMissing')
+        expect(e.message, 'error message').to.equal('Current password missing.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Current password incorrect', async function () {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'incorrect', newPassword: 'new-pass' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('CurrentPasswordIncorrect')
+        expect(e.message, 'error message').to.equal('Current password is incorrect.')
+        expect(e.status, 'error status').to.equal(401)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Password attempt limit exceeded', async function () {
+      const randomUser = 'test-user-' + getRandomString()
+      const password = getRandomString()
+      const rememberMe = 'none'
+
+      await this.test.userbase.signUp({
+        username: randomUser,
+        password,
+        rememberMe
+      })
+
+      for (let i = 0; i < 25; i++) {
+        try {
+          await this.test.userbase.updateUser({ currentPassword: 'incorrect', newPassword: 'new-pass' })
+          throw new Error('should have failed')
+        } catch (e) {
+          expect(e.name, 'error name').to.equal('CurrentPasswordIncorrect')
+          expect(e.message, 'error message').to.equal('Current password is incorrect.')
+          expect(e.status, 'error status').to.equal(401)
+        }
+
+        // cooldown for rate limiter
+        await wait(1000)
+      }
+
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'incorrect', newPassword: 'new-pass' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordAttemptLimitExceeded')
+        expect(e.message, 'error message').to.equal(`Password attempt limit exceeded. Must wait 24 hours to attempt to use password again.`)
+        expect(e.status, 'error status').to.equal(401)
+      }
+
+      // clean up
+      await this.test.userbase.deleteUser()
+    })
+
+    it('Current password must be string', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 1, newPassword: 'new-pass' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordMustBeString')
+        expect(e.message, 'error message').to.equal('Password must be a string.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('New password must be string', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'current-pass', newPassword: 1 })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordMustBeString')
+        expect(e.message, 'error message').to.equal('Password must be a string.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Current password blank', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: '', newPassword: 'new-pass' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordCannotBeBlank')
+        expect(e.message, 'error message').to.equal('Password cannot be blank.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('New password blank', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'curr-pass', newPassword: '' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordCannotBeBlank')
+        expect(e.message, 'error message').to.equal('Password cannot be blank.')
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Current password too short', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'cur', newPassword: 'new-pass' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordTooShort')
+        expect(e.message, 'error message').to.equal(`Password too short. Must be a minimum of 6 characters.`)
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('New password too short', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'cur-pass', newPassword: 'new' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordTooShort')
+        expect(e.message, 'error message').to.equal(`Password too short. Must be a minimum of 6 characters.`)
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('Current password too long', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'a'.repeat(1001), newPassword: 'new-pass' })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordTooLong')
+        expect(e.message, 'error message').to.equal(`Password too long. Must be a max of 1000 characters.`)
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
+
+    it('New password too long', async function () {
+      try {
+        await this.test.userbase.updateUser({ currentPassword: 'curr-pass', newPassword: 'a'.repeat(1001) })
+        throw new Error('should have failed')
+      } catch (e) {
+        expect(e.name, 'error name').to.equal('PasswordTooLong')
+        expect(e.message, 'error message').to.equal(`Password too long. Must be a max of 1000 characters.`)
+        expect(e.status, 'error status').to.equal(400)
+      }
+    })
 
   })
 
-  it('Update user\'s info, AppIdNotValid', function () {
-
-  })
-
-  it('Update user\'s info, UserNotFound', function () {
-
-  })
-
-  it('Update user\'s info, TooManyRequests', function () {
-
-  })
-
-  it('Update user\'s info, ServiceUnavailable', function () {
-
-  })
 })

--- a/src/userbase-js/src/config.js
+++ b/src/userbase-js/src/config.js
@@ -7,6 +7,7 @@ const STRIPE_PRODUCTION_PUBLISHABLE_KEY = 'pk_live_jI6lbsAIQlu2u4uTkDXFrSEW'
 const STRIPE_TEST_PUBLISHABLE_KEY = 'pk_test_rYANrLdNfdJXJ2d808wW4pqY'
 
 let userbaseAppId = null
+let userbaseUpdateUserHandler = null
 
 const REMEMBER_ME_OPTIONS = {
   local: true,
@@ -19,19 +20,16 @@ const getAppId = () => {
   return userbaseAppId
 }
 
+const getUpdateUserHandler = () => userbaseUpdateUserHandler
+
 const getEndpoint = () => {
   return window._userbaseEndpoint || DEFAULT_ENDPOINT
 }
 
-const setAppId = (appId) => {
+const configure = ({ appId, updateUserHandler }) => {
   if (userbaseAppId && userbaseAppId !== appId) throw new errors.AppIdAlreadySet(userbaseAppId)
-  if (typeof appId !== 'string') throw new errors.AppIdMustBeString
-  if (appId.length === 0) throw new errors.AppIdCannotBeBlank
   userbaseAppId = appId
-}
-
-const configure = ({ appId }) => {
-  setAppId(appId)
+  userbaseUpdateUserHandler = updateUserHandler
 }
 
 const getStripePublishableKey = (isProduction) => {
@@ -43,6 +41,7 @@ const getStripePublishableKey = (isProduction) => {
 export default {
   REMEMBER_ME_OPTIONS,
   getAppId,
+  getUpdateUserHandler,
   getEndpoint,
   configure,
   getStripePublishableKey,

--- a/src/userbase-js/src/errors/config.js
+++ b/src/userbase-js/src/errors/config.js
@@ -50,10 +50,20 @@ class WebCryptoUnavailable extends Error {
   }
 }
 
+class UpdateUserHandlerMustBeFunction extends Error {
+  constructor(...params) {
+    super(...params)
+
+    this.name = 'UpdateUserHandlerMustBeFunction'
+    this.message = 'Update user handler must be a function.'
+    this.status = statusCodes['Bad Request']
+  }
+}
 export default {
   AppIdAlreadySet,
   AppIdMustBeString,
   AppIdMissing,
   AppIdCannotBeBlank,
   WebCryptoUnavailable,
+  UpdateUserHandlerMustBeFunction,
 }

--- a/src/userbase-js/types/index.d.ts
+++ b/src/userbase-js/types/index.d.ts
@@ -1,6 +1,8 @@
 // Expose as userbase when loaded in an IIFE environment
 export as namespace userbase
 
+export type UpdateUserHandler = (updatedUser: { user: UserResult }) => void
+
 export interface Session {
   user?: UserResult
   lastUsedUsername?: string
@@ -28,6 +30,8 @@ export interface UserResult {
   email?: string
   profile?: UserProfile
   protectedProfile?: UserProfile
+  usedTempPassword?: boolean
+  passwordChanged?: boolean
 }
 
 export type DatabaseChangeHandler = (items: Item[]) => void
@@ -84,7 +88,7 @@ export interface CancelSubscriptionResult {
 }
 
 export interface Userbase {
-  init(params: { appId: string }): Promise<Session>
+  init(params: { appId: string, updateUserHandler?: UpdateUserHandler }): Promise<Session>
 
   signUp(params: { username: string, password: string, email?: string, profile?: UserProfile, rememberMe?: RememberMeOption }): Promise<UserResult>
 

--- a/src/userbase-js/types/test.ts
+++ b/src/userbase-js/types/test.ts
@@ -28,8 +28,14 @@ const {
 // $ExpectType Promise<Session>
 init({ appId: 'tid' })
 
+// $ExpectType Promise<Session>
+init({ appId: 'tid', updateUserHandler: ({ user }) => { } })
+
 // $ExpectError
 init({})
+
+// $ExpectError
+init({ appId: 'tid', updateUserHandler: 'tup' })
 
 // $ExpectType Promise<UserResult>
 signUp({ username: 'tuser', password: 'tpass' })

--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -576,7 +576,7 @@ const putTransaction = async function (transaction, userId, databaseId) {
   connections.push(transaction, userId)
 
   // broadcast transaction to all peers so they also push to their connected clients
-  peers.broadcast(transaction, userId)
+  peers.broadcastTransaction(transaction, userId)
 
   return transaction['sequence-no']
 }

--- a/src/userbase-server/peers.js
+++ b/src/userbase-server/peers.js
@@ -2,35 +2,61 @@ import request from 'request-promise-native'
 import logger from './logger'
 
 export default class Peers {
-  static async broadcast(transaction, userId) {
+  static buildNotifications(notify) {
     const notifications = []
 
     for (let i = 0; i < Peers.ipAddresses.length; i++) {
       const ipAddress = Peers.ipAddresses[i]
-
-      // best effort notify all other peers of transaction
-      const notify = async () => {
-        try {
-          await request({
-            method: 'POST',
-            uri: `http://${ipAddress}:9000/internal/notify-transaction`,
-            body: {
-              transaction,
-              userId
-            },
-            json: true
-          }).promise()
-
-        } catch (e) {
-          logger
-            .child({ userId, databaseId: transaction['database-id'], ipAddress, err: e })
-            .warn('Failed to notify db update')
-        }
-      }
-
-      notifications.push(notify())
+      notifications.push(notify(ipAddress))
     }
 
-    await Promise.all(notifications)
+    return notifications
+  }
+
+  static async broadcastTransaction(transaction, userId) {
+    // best effort notify all other peers of transaction
+    const notify = async (ipAddress) => {
+      try {
+        await request({
+          method: 'POST',
+          uri: `http://${ipAddress}:9000/internal/notify-transaction`,
+          body: {
+            transaction,
+            userId
+          },
+          json: true
+        }).promise()
+
+      } catch (e) {
+        logger
+          .child({ userId, databaseId: transaction['database-id'], ipAddress, err: e })
+          .warn('Failed to notify db update')
+      }
+    }
+
+    await Promise.all(this.buildNotifications(notify))
+  }
+
+  static async broadcastUpdatedUser(updatedUser) {
+    // best effort notify all other peers of updated user
+    const notify = async (ipAddress) => {
+      try {
+        await request({
+          method: 'POST',
+          uri: `http://${ipAddress}:9000/internal/notify-updated-user`,
+          body: {
+            updatedUser
+          },
+          json: true
+        }).promise()
+
+      } catch (e) {
+        logger
+          .child({ userId: updatedUser.userId, ipAddress, err: e })
+          .warn('Failed to notify user update')
+      }
+    }
+
+    await Promise.all(this.buildNotifications(notify))
   }
 }

--- a/src/userbase-server/ws.js
+++ b/src/userbase-server/ws.js
@@ -405,6 +405,26 @@ export default class Connections {
     }
   }
 
+  static pushUpdatedUser(updatedUser, thisConnectionId) {
+    const userId = updatedUser.userId
+    if (!Connections.sockets || !Connections.sockets[userId]) return
+
+    const payload = JSON.stringify({
+      route: 'UpdatedUser',
+      updatedUser,
+    })
+
+    for (const connectionId in Connections.sockets[userId]) {
+      // no need to push over WebSocket to current connection. Current connection will handle it in response to request
+      if (connectionId === thisConnectionId) continue
+
+      const conn = Connections.sockets[userId][connectionId]
+      if (conn.socket) {
+        conn.socket.send(payload)
+      }
+    }
+  }
+
   static close(connection) {
     const { userId, id, clientId, adminId, appId } = connection
     const connectionId = id


### PR DESCRIPTION
Credit to @raae for the suggestion in #172

- [init()](https://userbase.com/docs/sdk/init/) accepts a callback function as a parameter called `updateUserHandler`
- When a user is updated via [updateUser()](https://userbase.com/docs/sdk/update-user/) in the SDK from any client, or [Update User](https://userbase.com/docs/api/update-user/) in the Admin API, the callback function is invoked with the following object:
  - user
    - username
    - userId
    - authToken
    - creationDate
    - passwordChanged (only if changed)
    - email (only if set)
    - profile (only if set)
    - protectedProfile (only if set)
    - paymentsMode (only if set)
    - subscriptionStatus (only if set)
    - trialExpirationDate (only if set)
    - cancelSubscriptionAt (only if set)
- fixed a couple minor bugs
    - `updateUser()` now handles the `PasswordAttemptLimitExceeded` error correctly
    - `updateUser()` now handles the `PasswordCannotBeBlank` error correctly