### PR TITLE
Can manually set 'alt-saas-subscription-status' on admin to 'active'

### DIFF
--- a/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
+++ b/src/userbase-server/admin-panel/components/Admin/EditAdmin.jsx
@@ -122,7 +122,7 @@ export default class EditAdmin extends Component {
 
   handleUpgradeAtLoad() {
     // only attempt upgrade if admin does not already have a subscription
-    if (!this.props.admin.paymentStatus) {
+    if (!this.props.admin.paymentStatus && !this.props.admin.altPaymentStatus) {
       this.handleCheckout()
     }
   }
@@ -566,6 +566,7 @@ export default class EditAdmin extends Component {
       cancelPaymentsAddOnSubscriptionAt,
       storageSubscriptionStatus,
       cancelStorageSubscriptionAt,
+      altPaymentStatus,
     } = admin
     const {
       fullName,
@@ -638,49 +639,59 @@ export default class EditAdmin extends Component {
 
                   {errorUpdatingPaymentMethod && <UnknownError action='loading the form to update your payment method' />}
 
+                  <hr className='border border-t-0 border-gray-400 mt-8 mb-4' />
+
                 </div>
                 :
                 <div>
-                  <div className='flex-0 text-lg sm:text-xl text-left mb-4'>Userbase Subscription</div>
+                  {
+                    altPaymentStatus !== 'active' &&
+                    <div>
+                      <div className='flex-0 text-lg sm:text-xl text-left mb-4'>Userbase Subscription</div>
 
-                  <div className='font-normal text-left mb-4'>
-                    <p>Your trial account is limited to 1 app and 3 users.</p>
-                    <p>Remove this limit with a Userbase subscription for only $49 per year.</p>
-                  </div>
+                      <div className='font-normal text-left mb-4'>
+                        <p>Your trial account is limited to 1 app and 3 users.</p>
+                        <p>Remove this limit with a Userbase subscription for only $49 per year.</p>
+                      </div>
 
-                  {cancelSaasSubscriptionAt
-                    ? <input
-                      className='btn w-56 text-center'
-                      type='button'
-                      role='link'
-                      value={loadingResumeSubscription ? 'Resuming Subscription...' : 'Resume Subscription'}
-                      disabled={loadingResumeSubscription}
-                      onClick={this.handleResumeSubscription}
-                    />
-                    : <input
-                      className='btn w-56 text-center'
-                      type='button'
-                      role='link'
-                      disabled={loadingCheckout}
-                      value={loadingCheckout ? 'Loading...' : 'Buy Subscription'}
-                      onClick={this.handleCheckout}
-                    />
+                      {cancelSaasSubscriptionAt
+                        ? <input
+                          className='btn w-56 text-center'
+                          type='button'
+                          role='link'
+                          value={loadingResumeSubscription ? 'Resuming Subscription...' : 'Resume Subscription'}
+                          disabled={loadingResumeSubscription}
+                          onClick={this.handleResumeSubscription}
+                        />
+                        : <input
+                          className='btn w-56 text-center'
+                          type='button'
+                          role='link'
+                          disabled={loadingCheckout}
+                          value={loadingCheckout ? 'Loading...' : 'Buy Subscription'}
+                          onClick={this.handleCheckout}
+                        />
+                      }
+
+                      {errorCheckingOut && <UnknownError action='loading the checkout form' />}
+                      {errorResumingSubscription && <UnknownError action='resuming your subscription' />}
+
+                      <hr className='border border-t-0 border-gray-400 mt-8 mb-4' />
+
+                    </div>
                   }
-
-                  {errorCheckingOut && <UnknownError action='loading the checkout form' />}
-                  {errorResumingSubscription && <UnknownError action='resuming your subscription' />}
-
                 </div>
               }
-
-              <hr className='border border-t-0 border-gray-400 mt-8 mb-4' />
 
               {(!storageSubscriptionStatus || cancelStorageSubscriptionAt) &&
                 <div>
                   <div className='flex-0 text-lg sm:text-xl text-left mb-4'>Storage Plan</div>
                   <div className='font-normal text-left mb-4'>
                     <p>Store up to 1 terabyte of data for an additional $99 per year.</p>
-                    {(paymentStatus !== 'active' || cancelSaasSubscriptionAt) && <p>You must have an active Userbase subscription.</p>}
+                    {(paymentStatus !== 'active' || cancelSaasSubscriptionAt) && (altPaymentStatus !== 'active'
+                      ? <p>You must have an active Userbase subscription.</p>
+                      : <p>Please contact <a href='mailto:support@userbase.com'>support@userbase.com</a> to enable this feature.</p>
+                    )}
                   </div>
 
                   {
@@ -717,7 +728,10 @@ export default class EditAdmin extends Component {
                   <div className='flex-0 text-lg sm:text-xl text-left mb-4'>Payments Portal Add-On</div>
                   <div className='font-normal text-left mb-4'>
                     <p>Collect payments on your apps with Stripe for an additional ${PAYMENTS_ADD_ON_PRICE} per year.</p>
-                    {(paymentStatus !== 'active' || cancelSaasSubscriptionAt) && <p>You must have an active Userbase subscription.</p>}
+                    {(paymentStatus !== 'active' || cancelSaasSubscriptionAt) && (altPaymentStatus !== 'active'
+                      ? <p>You must have an active Userbase subscription.</p>
+                      : <p>Please contact <a href='mailto:support@userbase.com'>support@userbase.com</a> to enable this feature.</p>
+                    )}
                   </div>
 
                   {

--- a/src/userbase-server/admin-panel/components/Admin/logic.js
+++ b/src/userbase-server/admin-panel/components/Admin/logic.js
@@ -405,6 +405,12 @@ const disconnectStripeAccount = async () => {
   }
 }
 
+const saasSubscriptionNotActive = (admin) => {
+  const { paymentStatus, cancelSaasSubscriptionAt, altPaymentStatus } = admin
+  return (paymentStatus !== 'active' || cancelSaasSubscriptionAt) &&
+    altPaymentStatus !== 'active'
+}
+
 export default {
   createAdmin,
   createApp,
@@ -432,4 +438,5 @@ export default {
   deleteAccessToken,
   completeStripeConnection,
   disconnectStripeAccount,
+  saasSubscriptionNotActive,
 }

--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -3,6 +3,7 @@ import { string, object } from 'prop-types'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faTrashAlt } from '@fortawesome/free-regular-svg-icons'
 import dashboardLogic from './logic'
+import adminLogic from '../Admin/logic'
 import UnknownError from '../Admin/UnknownError'
 import { formatDate, formatSize } from '../../utils'
 import { ProfileTable } from './ProfileTable'
@@ -573,7 +574,7 @@ export default class AppUsersTable extends Component {
 
   render() {
     const { appName, admin } = this.props
-    const { paymentStatus, cancelSaasSubscriptionAt, connectedToStripe } = admin
+    const { connectedToStripe } = admin
     const {
       loading,
       activeUsers,
@@ -614,7 +615,7 @@ export default class AppUsersTable extends Component {
               </span>
             </div>
             {
-              paymentStatus === 'active' && !cancelSaasSubscriptionAt ? <div />
+              !adminLogic.saasSubscriptionNotActive(admin) ? <div />
                 : <div className='text-left mb-4 text-red-600 font-normal'>
                   Your account is limited to 1 app and 3 users. <a href="#edit-account">Remove this limit</a> with a Userbase subscription.
                 </div>
@@ -886,7 +887,7 @@ export default class AppUsersTable extends Component {
           {
             prodPaymentsAllowed(admin) ? <div />
               : <div className='text-left mb-6 text-red-600 font-normal'>
-                Your account is limited to test payments. <a href="#edit-account">Remove this limit</a> with {(paymentStatus !== 'active' || cancelSaasSubscriptionAt) ? 'a Userbase subscription and' : ''} the payments portal add-on.
+                Your account is limited to test payments. <a href="#edit-account">Remove this limit</a> with {adminLogic.saasSubscriptionNotActive(admin) ? 'a Userbase subscription and' : ''} the payments portal add-on.
               </div>
           }
 
@@ -1087,8 +1088,9 @@ export default class AppUsersTable extends Component {
             )}
           </div>
 
-          {(paymentStatus === 'active' && !cancelSaasSubscriptionAt)
-            ? <div>
+          {adminLogic.saasSubscriptionNotActive(admin)
+            ? <div />
+            : <div>
               <hr className='border border-t-0 border-gray-400 mt-8 mb-6' />
 
               <div className='flex-0 text-lg sm:text-xl text-left mb-4 text-red-600'>Danger Zone</div>
@@ -1105,7 +1107,6 @@ export default class AppUsersTable extends Component {
                 />
               </div>
             </div>
-            : <div />
           }
 
         </div>

--- a/src/userbase-server/admin-panel/components/Dashboard/Dashboard.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/Dashboard.jsx
@@ -150,7 +150,8 @@ export default class Dashboard extends Component {
   }
 
   render() {
-    const { paymentStatus, cancelSaasSubscriptionAt, size, sizeAllowed } = this.props.admin
+    const { admin } = this.props
+    const { size, sizeAllowed } = admin
     const { loading, activeApps, deletedApps, showDeletedApps, error, appName, loadingApp } = this.state
 
     return (
@@ -174,7 +175,7 @@ export default class Dashboard extends Component {
               </div>
 
               {
-                (paymentStatus === 'active' && !cancelSaasSubscriptionAt) ? <div />
+                (!adminLogic.saasSubscriptionNotActive(admin)) ? <div />
                   : <div className='text-left mb-4 text-red-600 font-normal'>
                     Your account is limited to 1 app and 3 users. <a href="#edit-account">Remove this limit</a> with a Userbase subscription.
                 </div>
@@ -216,7 +217,7 @@ export default class Dashboard extends Component {
                 </table>
               }
 
-              {paymentStatus === 'active' && !cancelSaasSubscriptionAt &&
+              {!adminLogic.saasSubscriptionNotActive(admin) &&
 
                 <form className={`flex text-left ${(activeApps && activeApps.length) ? 'mt-8' : ''}`}>
                   <div className='flex-1'>

--- a/src/userbase-server/admin.js
+++ b/src/userbase-server/admin.js
@@ -248,6 +248,7 @@ const _buildAdminResult = (admin) => {
     cancelPaymentsAddOnSubscriptionAt: admin['stripe-cancel-payments-add-on-subscription-at'],
     storageSubscriptionStatus: admin['stripe-storage-subscription-status'],
     cancelStorageSubscriptionAt: admin['stripe-cancel-storage-subscription-at'],
+    altPaymentStatus: admin['alt-saas-subscription-status'],
     size: admin['size'],
     sizeAllowed: _getSizeAllowed(admin),
   }
@@ -1611,3 +1612,9 @@ const prodPaymentsEnabled = (admin) => {
   )
 }
 exports.prodPaymentsEnabled = prodPaymentsEnabled
+
+const saasSubscriptionNotActive = (admin) => {
+  return (admin['stripe-saas-subscription-status'] !== 'active' || admin['stripe-cancel-saas-subscription-at']) &&
+    admin['alt-saas-subscription-status'] !== 'active'
+}
+exports.saasSubscriptionNotActive = saasSubscriptionNotActive

--- a/src/userbase-server/app.js
+++ b/src/userbase-server/app.js
@@ -5,6 +5,7 @@ import statusCodes from './statusCodes'
 import setup from './setup'
 import userController from './user'
 import stripe from './stripe'
+import adminController from './admin'
 import { trimReq, lastEvaluatedKeyToNextPageToken, nextPageTokenToLastEvaluatedKey } from './utils'
 
 const UUID_STRING_LENGTH = 36
@@ -65,7 +66,7 @@ exports.createAppController = async function (req, res) {
   const admin = res.locals.admin
   const adminId = admin['admin-id']
 
-  if (admin['stripe-saas-subscription-status'] !== 'active' || admin['stripe-cancel-saas-subscription-at']) return res
+  if (adminController.saasSubscriptionNotActive(admin)) return res
     .status(statusCodes['Payment Required'])
     .send('Pay subscription fee to create an app.')
 
@@ -185,7 +186,7 @@ exports.deleteApp = async function (req, res) {
   const admin = res.locals.admin
   const adminId = admin['admin-id']
 
-  if (admin['stripe-saas-subscription-status'] !== 'active' || admin['stripe-cancel-saas-subscription-at']) return res
+  if (adminController.saasSubscriptionNotActive(admin)) return res
     .status(statusCodes['Payment Required'])
     .send('Pay subscription fee to delete an app.')
 
@@ -277,7 +278,7 @@ exports.permanentDeleteAppController = async function (req, res) {
   const admin = res.locals.admin
   const adminId = admin['admin-id']
 
-  if (admin['stripe-saas-subscription-status'] !== 'active' || admin['stripe-cancel-saas-subscription-at']) return res
+  if (adminController.saasSubscriptionNotActive(admin)) return res
     .status(statusCodes['Payment Required'])
     .send('Pay subscription fee to permanently delete an app.')
 

--- a/src/userbase-server/user.js
+++ b/src/userbase-server/user.js
@@ -420,9 +420,8 @@ const _validateSignUpInput = (appId, username, passwordToken, publicKeyData, pas
   }
 }
 
-const _validateSubscription = async (status, cancelAt, appId) => {
-  const unpaidSubscription = status !== 'active' || cancelAt
-  if (unpaidSubscription) {
+const _validateSubscription = async (admin, appId) => {
+  if (adminController.saasSubscriptionNotActive(admin)) {
     const numUsers = await appController.countNonDeletedAppUsers(appId, LIMIT_NUM_TRIAL_USERS)
     if (numUsers >= LIMIT_NUM_TRIAL_USERS) {
       throw {
@@ -486,7 +485,7 @@ exports.signUp = async function (req, res) {
       logChildObject.adminId = admin['admin-id']
     }
 
-    await _validateSubscription(admin['stripe-saas-subscription-status'], admin['stripe-cancel-saas-subscription-at'], appId)
+    await _validateSubscription(admin, appId)
 
     const params = _buildSignUpParams(username, passwordToken, appId, userId,
       publicKeyData, passwordSalts, keySalts, email, profile, passwordBasedBackup)


### PR DESCRIPTION
- has all the same features as an admin account with active SaaS subscription
- must contact support to enable payments add-on + storage