### PR TITLE
UI update for active & pending deletion user tables

### DIFF
--- a/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
+++ b/src/userbase-server/admin-panel/components/Dashboard/AppUsersTable.jsx
@@ -642,7 +642,7 @@ export default class AppUsersTable extends Component {
               ?
               <div>
                 {activeUsers && activeUsers.length > 0 &&
-                  <div className='text-center overflow-scroll whitespace-no-wrap'>
+                  <div className='text-center overflow-auto whitespace-no-wrap'>
                     <table className='table-auto w-full border-none mx-auto text-xs'>
 
                       <thead>
@@ -753,7 +753,7 @@ export default class AppUsersTable extends Component {
                     </a>
 
                     {showDeletedUsers &&
-                      <div className='text-center overflow-scroll whitespace-no-wrap'>
+                      <div className='text-center overflow-auto whitespace-no-wrap'>
                         <table className='mt-6 table-auto w-full border-none mx-auto text-xs'>
 
                           <thead>


### PR DESCRIPTION
Small UI tweak for the active and pending deletion user tables. Changing `overflow-scroll` -> `overflow-auto` in order to only show scroll bars if overflow exists.

Original:
![Screen Shot 2020-08-14 at 6 01 28 PM](https://user-images.githubusercontent.com/32587255/90295967-45eefd00-de58-11ea-8494-8d81af21c50a.png)

Proposed:
![Screen Shot 2020-08-14 at 6 02 51 PM](https://user-images.githubusercontent.com/32587255/90296009-615a0800-de58-11ea-8ecf-2790ca9c9a3d.png)


