### PR TITLE
Fix getFile() after user has inserted a large amount of data into database

### DIFF
--- a/src/userbase-js/CHANGELOG.md
+++ b/src/userbase-js/CHANGELOG.md
@@ -1,4 +1,10 @@
+## [2.1.1] - 2020-08-15
+### Fixed
+- getFile() works after user has inserted many items into a database instead of throwing FileNotFound.
+
 ## [2.1.0] - 2020-08-12
+Note: Deprecated. Please use the latest version.
+
 ### Added
 - uploadFile() to enable file storage.
 - getFile() to enable retrieving files.

--- a/src/userbase-js/package-lock.json
+++ b/src/userbase-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "userbase-js",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/userbase-js/package.json
+++ b/src/userbase-js/package.json
@@ -33,7 +33,7 @@
     "type": "git",
     "url": "git+https://github.com/encrypted-dev/userbase.git"
   },
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "prepublishOnly": "npm run build",
     "build": "npm run build:esm && npm run build:cjs && npm run build:umd",

--- a/src/userbase-js/src/api/auth.js
+++ b/src/userbase-js/src/api/auth.js
@@ -52,7 +52,7 @@ const signUp = (username, passwordToken, ecKeyData, passwordSalts, keySalts, ema
     const xhr = new XMLHttpRequest()
 
     const method = 'POST'
-    const url = `${config.getEndpoint()}/api/auth/sign-up?appId=${config.getAppId()}`
+    const url = `${config.getEndpoint()}/api/auth/sign-up?appId=${config.getAppId()}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
     const data = JSON.stringify({
       username,
       passwordToken,
@@ -78,7 +78,7 @@ const getPasswordSalts = (username) => {
     const xhr = new XMLHttpRequest()
 
     const method = 'GET'
-    const url = `${config.getEndpoint()}/api/auth/get-password-salts?appId=${config.getAppId()}&username=${encodeURIComponent(username)}`
+    const url = `${config.getEndpoint()}/api/auth/get-password-salts?appId=${config.getAppId()}&username=${encodeURIComponent(username)}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
 
     xhr.open(method, url)
     xhr.send()
@@ -92,7 +92,7 @@ const signIn = async (username, passwordToken, sessionLength) => {
     const xhr = new XMLHttpRequest()
 
     const method = 'POST'
-    const url = `${config.getEndpoint()}/api/auth/sign-in?appId=${config.getAppId()}`
+    const url = `${config.getEndpoint()}/api/auth/sign-in?appId=${config.getAppId()}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
     const data = JSON.stringify({
       username,
       passwordToken,
@@ -112,7 +112,7 @@ const signInWithSession = (sessionId, sessionLength) => {
     const xhr = new XMLHttpRequest()
 
     const method = 'POST'
-    const url = `${config.getEndpoint()}/api/auth/sign-in-with-session?appId=${config.getAppId()}&sessionId=${sessionId}`
+    const url = `${config.getEndpoint()}/api/auth/sign-in-with-session?appId=${config.getAppId()}&sessionId=${sessionId}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
     const data = JSON.stringify({
       sessionLength,
     })
@@ -130,7 +130,7 @@ const getServerPublicKey = async () => {
     const xhr = new XMLHttpRequest()
 
     const method = 'GET'
-    const url = `${config.getEndpoint()}/api/auth/server-public-key`
+    const url = `${config.getEndpoint()}/api/auth/server-public-key?&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
     const responseType = 'arraybuffer'
 
     xhr.open(method, url)
@@ -146,7 +146,7 @@ const getPublicKey = (username) => {
     const xhr = new XMLHttpRequest()
 
     const method = 'GET'
-    const url = `${config.getEndpoint()}/api/public-key?appId=${config.getAppId()}&username=${encodeURIComponent(username)}`
+    const url = `${config.getEndpoint()}/api/public-key?appId=${config.getAppId()}&username=${encodeURIComponent(username)}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
 
     xhr.open(method, url)
     xhr.send()

--- a/src/userbase-js/src/config.js
+++ b/src/userbase-js/src/config.js
@@ -1,5 +1,7 @@
 import errors from './errors'
 
+const USERBASE_JS_VERSION = '2.1.1'
+
 const VERSION = '/v1'
 const DEFAULT_ENDPOINT = 'https://v1.userbase.com' + VERSION
 
@@ -39,6 +41,7 @@ const getStripePublishableKey = (isProduction) => {
 }
 
 export default {
+  USERBASE_JS_VERSION,
   REMEMBER_ME_OPTIONS,
   getAppId,
   getUpdateUserHandler,

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -193,7 +193,7 @@ class Connection {
                 const plaintextString = LZString.decompress(compressedString)
                 const bundle = JSON.parse(plaintextString)
 
-                database.applyBundle(bundle, bundleSeqNo)
+                await database.applyBundle(bundle, bundleSeqNo)
               }
 
               const newTransactions = message.transactionLog

--- a/src/userbase-js/src/ws.js
+++ b/src/userbase-js/src/ws.js
@@ -100,7 +100,7 @@ class Connection {
         10000
       )
 
-      const url = `${getWsUrl(config.getEndpoint())}/api?appId=${config.getAppId()}&sessionId=${session.sessionId}&clientId=${clientId}`
+      const url = `${getWsUrl(config.getEndpoint())}/api?appId=${config.getAppId()}&sessionId=${session.sessionId}&clientId=${clientId}&userbaseJsVersion=${config.USERBASE_JS_VERSION}`
 
       const ws = new WebSocket(url)
 

--- a/src/userbase-server/package-lock.json
+++ b/src/userbase-server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "userbase-server",
-  "version": "0.0.51",
+  "version": "0.0.53",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/userbase-server/package.json
+++ b/src/userbase-server/package.json
@@ -35,5 +35,5 @@
     "type": "git",
     "url": "git+https://github.com/encrypted-dev/userbase.git"
   },
-  "version": "0.0.51"
+  "version": "0.0.53"
 }


### PR DESCRIPTION
### Overview

File storage works by attaching a file to an item. Each file has a distinct file encryption key that is also stored alongside the item on the server (the file encryption key is encrypted using the database’s encryption key).

Further, once a user's database exceeds a certain size, the client initiates a bundling process that bundles all items in the database together for performance reasons. This process is explained further [in the Userbase architecture spec](https://github.com/encrypted-dev/userbase/blob/78e5fbf9cbfa7562acb3584c3ee85312c60266be/docs/userbase_architecture.md#bundling).

In userbase-js 2.1.0, when the bundling process is triggered, the client would not correctly bundle file encryption keys alongside items, nor would it correctly read the file metadata back from the bundle. Because of this, files couldn't be read after the bundling process is triggered.

This patch fixes this issue and logs the userbase-js version clients are using.