### PR TITLE
getDatabases() takes databaseName or databaseId as filter param

### DIFF
--- a/src/userbase-server/db.js
+++ b/src/userbase-server/db.js
@@ -282,9 +282,18 @@ const _queryUserDatabases = async (userId, nextPageToken) => {
   return userDbsResponse
 }
 
-exports.getDatabases = async function (logChildObject, userId, nextPageToken) {
+exports.getDatabases = async function (logChildObject, userId, nextPageToken, databaseId, dbNameHash) {
   try {
-    const userDbsResponse = await _queryUserDatabases(userId, nextPageToken)
+    let userDbsResponse
+    if (!databaseId && !dbNameHash) {
+      userDbsResponse = await _queryUserDatabases(userId, nextPageToken, databaseId, dbNameHash)
+    } else if (databaseId) {
+      const userDb = await await _getUserDatabaseByUserIdAndDatabaseId(userId, databaseId)
+      userDbsResponse = { Items: userDb ? [userDb] : [] }
+    } else {
+      const userDb = await _getUserDatabase(userId, dbNameHash)
+      userDbsResponse = { Items: userDb ? [userDb] : [] }
+    }
     const userDbs = userDbsResponse.Items
 
     const [databases, senders] = await Promise.all([

--- a/src/userbase-server/server.js
+++ b/src/userbase-server/server.js
@@ -215,7 +215,7 @@ async function start(express, app, userbaseConfig = {}) {
                     break
                   }
                   case 'GetDatabases': {
-                    response = await db.getDatabases(logChildObject, res.locals.user['user-id'], params.nextPageToken)
+                    response = await db.getDatabases(logChildObject, res.locals.user['user-id'], params.nextPageToken, params.databaseId, params.dbNameHash)
                     break
                   }
                   case 'GetDatabaseUsers': {


### PR DESCRIPTION
As requested by @jneterer  in #189, this offers a convenient way to retrieve a single database's metadata using its name or ID.