### PR TITLE
Fix error message for 'UserNotVerified' error

### DIFF
--- a/src/userbase-js/src/errors/db.js
+++ b/src/userbase-js/src/errors/db.js
@@ -605,7 +605,7 @@ class UserNotVerified extends Error {
     super(...params)
 
     this.name = 'UserNotVerified'
-    this.message = 'User not verified. Either verify user before sharing database, or set requireVerified to true.'
+    this.message = 'User not verified. Either verify user before sharing database, or set requireVerified to false.'
     this.status = statusCodes['Forbidden']
   }
 }


### PR DESCRIPTION
Hi, 

Thanks for this awesome piece of software! 

I was experimenting with the **shareDatabase** functionality when I stumbled upon the following error:

> User not verified. Either verify user before sharing database, or set requireVerified to **true**.

It took me a minute to realise the latter should be "false" if you don't want to verify a user.
This fix changes **true** to **false** in the thrown error message.
